### PR TITLE
Don't treat a hold of modifier key as multiple keystrokes

### DIFF
--- a/app/hid.py
+++ b/app/hid.py
@@ -9,6 +9,15 @@ class WriteError(Error):
     pass
 
 
+KEYCODE_LEFT_CTRL = 0xe0
+KEYCODE_LEFT_SHIFT = 0xe1
+KEYCODE_LEFT_ALT = 0xe2
+KEYCODE_LEFT_META = 0xe3
+_MODIFIER_KEYCODES = [
+    KEYCODE_LEFT_CTRL, KEYCODE_LEFT_SHIFT, KEYCODE_LEFT_ALT, KEYCODE_LEFT_META
+]
+
+
 def _write_to_hid_interface(hid_path, buffer):
     with open(hid_path, 'wb+') as hid_handle:
         hid_handle.write(bytearray(buffer))
@@ -16,10 +25,15 @@ def _write_to_hid_interface(hid_path, buffer):
 
 def send(hid_path, control_keys, hid_keycode):
     # First 8 bytes are for the first keystorke. Second 8 bytes are
-    # all zeroes to indicate completion of the keypress.
-    buf = [0] * 16
+    # all zeroes to indicate release of keys.
+    buf = [0] * 8
     buf[0] = control_keys
     buf[2] = hid_keycode
+
+    # If it's not a modifier keycode, add a message indicating that the key
+    # should be released after it is sent.
+    if hid_keycode not in _MODIFIER_KEYCODES:
+        buf += [0] * 8
 
     # Writes can time out, so attempt the write in a separate thread to avoid
     # hanging.

--- a/app/js_to_hid.py
+++ b/app/js_to_hid.py
@@ -1,5 +1,7 @@
 import dataclasses
 
+import hid
+
 
 class Error(Exception):
     pass
@@ -31,9 +33,9 @@ _JS_TO_HID_KEYCODES = {
     9: 0x2b,  # Tab
     12: 0x53,  # Clear
     13: 0x28,  # Enter
-    16: 0xe1,  # Shift (Left)
-    17: 0xe0,  # Ctrl (left)
-    18: 0xe1,  # Alt (left)
+    16: hid.KEYCODE_LEFT_SHIFT,
+    17: hid.KEYCODE_LEFT_CTRL,
+    18: hid.KEYCODE_LEFT_ALT,
     19: 0x48,  # Pause / Break
     20: 0x39,  # Caps Lock
     21: 0x90,  # Hangeul
@@ -93,7 +95,7 @@ _JS_TO_HID_KEYCODES = {
     88: 0x1b,  # x
     89: 0x1c,  # y
     90: 0x1d,  # z
-    91: 0xe3,  # Windows key / Meta Key (Left)
+    91: hid.KEYCODE_LEFT_META,
     96: 0x62,  # Numpad 0
     97: 0x59,  # Numpad 1
     98: 0x5a,  # Numpad 2

--- a/app/main.py
+++ b/app/main.py
@@ -71,6 +71,14 @@ def socket_keystroke(message):
     socketio.emit('keystroke-received', {'success': True})
 
 
+@socketio.on('keyRelease')
+def socket_key_release():
+    try:
+        hid.clear(hid_path)
+    except hid.WriteError as e:
+        logger.error('Failed to release keys: %s', e)
+
+
 @socketio.on('connect')
 def test_connect():
     logger.info('Client connected')

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -228,6 +228,12 @@ function onKeyDown(evt) {
 
 function onKeyUp(evt) {
   keyState[evt.keyCode] = false;
+  if (!connectedToKeyboardService) {
+    return;
+  }
+  if (isModifierKeyCode(evt.keyCode)) {
+    keyboardSocket.emit("keyRelease");
+  }
 }
 
 function onManualModifierButtonClicked(evt) {


### PR DESCRIPTION
By default, JavaScript continuously generates onKeyDown events as long as the user holds down a key. This is fine for most keys, as holding down a key should be the same as repeatedly pushing a key. For modifier keys like Shift + Ctrl + Alt + Meta/OS, it yields unexpected behavior, like Windows triggering StickyKeys.

This fix adds special casing for modifier keys so that they don't trigger multiple key presses when held down.

Fixes #60