### PR TITLE
Eliminate assumption that hostname is tinypilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,19 +110,19 @@ To enable TinyPilot's Git hooks, run:
 To run TinyPilot on a non-Pi machine, run:
 
 ```bash
-PORT=8000 HID_PATH=/dev/null CORS_ORIGIN="http://$(hostname)" ./app/main.py
+PORT=8000 HID_PATH=/dev/null ./app/main.py
 ```
 
 ## Options
 
 TinyPilot accepts various options through environment variables:
 
-| Environment Variable | Default            | Description |
-|----------------------|--------------------|-------------|
-| `HOST`               | `0.0.0.0`          | Network interface to listen for incoming connections. |
-| `PORT`               | `8000`             | HTTP port to listen for incoming connections. |
-| `HID_PATH`           | `/dev/hidg0`       | Path to keyboard HID interface. |
-| `CORS_ORIGIN`        | `http://tinypilot` | Origin from which TinyPilot should allow CORS requests. |
+| Environment Variable | Default              | Description |
+|----------------------|----------------------|-------------|
+| `HOST`               | `0.0.0.0`            | Network interface to listen for incoming connections. |
+| `PORT`               | `8000`               | HTTP port to listen for incoming connections. |
+| `HID_PATH`           | `/dev/hidg0`         | Path to keyboard HID interface. |
+| `CORS_ORIGIN`        | `http://${HOSTNAME}` | Origin from which TinyPilot should allow CORS requests. |
 
 ## Security considerations
 

--- a/app/local_system.py
+++ b/app/local_system.py
@@ -1,4 +1,5 @@
 import logging
+import platform
 import subprocess
 
 logger = logging.getLogger(__name__)
@@ -10,6 +11,10 @@ class Error(Exception):
 
 class ShutdownError(Error):
     pass
+
+
+def hostname():
+    return platform.node()
 
 
 def shutdown():

--- a/app/main.py
+++ b/app/main.py
@@ -27,7 +27,7 @@ port = int(os.environ.get('PORT', 8000))
 debug = 'DEBUG' in os.environ
 # Location of HID file handle in which to write keyboard HID input.
 hid_path = os.environ.get('HID_PATH', '/dev/hidg0')
-cors_origin = os.environ.get('CORS_ORIGIN', 'http://tinypilot')
+cors_origin = os.environ.get('CORS_ORIGIN', 'http://' + local_system.hostname())
 
 app = flask.Flask(__name__, static_url_path='')
 socketio = flask_socketio.SocketIO(app, cors_allowed_origins=[cors_origin])


### PR DESCRIPTION
Change CORS_ORIGIN to default to the local machine's hostname rather than assume that the machine is called 'tinypilot'.

Fixes #83