### PR TITLE
Adding wheel install to the quick-install script

### DIFF
--- a/quick-install
+++ b/quick-install
@@ -19,6 +19,8 @@ pushd $(mktemp -d)
 sudo apt-get install -y python3-venv
 python3 -m venv venv
 . venv/bin/activate
+# Ansible depends on wheel.
+pip install wheel==0.34.2
 pip install ansible==2.9.10
 echo "[defaults]
 roles_path = $PWD


### PR DESCRIPTION
Ansible spews error messages if wheel isn't installed. They're benign, but it's cleaner if we just pre-install wheel.