### PR TITLE
Allow wildcard origin for CORS requests to socket.io routes (re-try)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,12 +121,11 @@ PORT=8000 HID_PATH=/dev/null ./app/main.py
 
 TinyPilot accepts various options through environment variables:
 
-| Environment Variable | Default              | Description |
-|----------------------|----------------------|-------------|
-| `HOST`               | `0.0.0.0`            | Network interface to listen for incoming connections. |
-| `PORT`               | `8000`               | HTTP port to listen for incoming connections. |
-| `HID_PATH`           | `/dev/hidg0`         | Path to keyboard HID interface. |
-| `CORS_ORIGIN`        | `http://${HOSTNAME}` | Origin from which TinyPilot should allow CORS requests. |
+| Environment Variable | Default      | Description |
+|----------------------|--------------|-------------|
+| `HOST`               | `0.0.0.0`    | Network interface to listen for incoming connections. |
+| `PORT`               | `8000`       | HTTP port to listen for incoming connections. |
+| `HID_PATH`           | `/dev/hidg0` | Path to keyboard HID interface. |
 
 ## Upgrades
 

--- a/app/main.py
+++ b/app/main.py
@@ -27,10 +27,15 @@ port = int(os.environ.get('PORT', 8000))
 debug = 'DEBUG' in os.environ
 # Location of HID file handle in which to write keyboard HID input.
 hid_path = os.environ.get('HID_PATH', '/dev/hidg0')
-cors_origin = os.environ.get('CORS_ORIGIN', 'http://' + local_system.hostname())
 
 app = flask.Flask(__name__, static_url_path='')
-socketio = flask_socketio.SocketIO(app, cors_allowed_origins=[cors_origin])
+# TODO(mtlynch): Ideally, we wouldn't accept requests from any origin, but the
+# risk of a CSRF attack for this app is very low. Additionally, CORS doesn't
+# protect us from the dangerous part of a CSRF attack. Even without same-origin
+# enforcement, third-party pages can still *send* requests (i.e. inject
+# keystrokes into the target machine) - it doesn't matter much if they can't
+# read responses.
+socketio = flask_socketio.SocketIO(app, cors_allowed_origins='*')
 
 # Configure CSRF protection.
 csrf = flask_wtf.csrf.CSRFProtect(app)


### PR DESCRIPTION
Retrying this change. The first time (#98), I incorrectly applied the cors_allowed_origins parameter.