### PR TITLE
Ensure all apt packages are installed for Ansible

### DIFF
--- a/quick-install
+++ b/quick-install
@@ -16,7 +16,7 @@ if [ -f /etc/nginx/sites-enabled/KVMPi.conf ]; then
 fi
 
 pushd $(mktemp -d)
-sudo apt-get install -y python3-venv
+sudo apt-get install -y libssl-dev python3-dev python3-venv
 python3 -m venv venv
 . venv/bin/activate
 # Ansible depends on wheel.
@@ -24,6 +24,7 @@ pip install wheel==0.34.2
 pip install ansible==2.9.10
 echo "[defaults]
 roles_path = $PWD
+interpreter_python = /usr/bin/python3
 " > ansible.cfg
 ansible-galaxy install mtlynch.tinypilot
 echo "- hosts: localhost


### PR DESCRIPTION
On non-Raspbian Debian systems like DietPi, we should check that all the apt packages are available to run the Ansible environment.