### PR TITLE
Relax assumption that keyboard == HID

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ To enable TinyPilot's Git hooks, run:
 To run TinyPilot on a non-Pi machine, run:
 
 ```bash
-PORT=8000 HID_PATH=/dev/null ./app/main.py
+PORT=8000 KEYBOARD_INTERFACE=/dev/null ./app/main.py
 ```
 
 ## Options
@@ -129,7 +129,7 @@ TinyPilot accepts various options through environment variables:
 |----------------------|--------------|-------------|
 | `HOST`               | `0.0.0.0`    | Network interface to listen for incoming connections. |
 | `PORT`               | `8000`       | HTTP port to listen for incoming connections. |
-| `HID_PATH`           | `/dev/hidg0` | Path to keyboard HID interface. |
+| `KEYBOARD_INTERFACE` | `/dev/hidg0` | Path to keyboard HID interface. |
 
 ## Upgrades
 

--- a/app/hid.py
+++ b/app/hid.py
@@ -36,19 +36,19 @@ def _write_to_hid_interface_with_timeout(hid_path, buffer):
             'Failed to write to HID interface. Is USB cable connected?')
 
 
-def send(hid_path, control_keys, hid_keycode):
-    # First 8 bytes are for the first keystorke. Second 8 bytes are
+def send_keystroke(keyboard_path, control_keys, hid_keycode):
+    # First 8 bytes are for the first keystroke. Second 8 bytes are
     # all zeroes to indicate release of keys.
     buf = [0] * 8
     buf[0] = control_keys
     buf[2] = hid_keycode
-    _write_to_hid_interface_with_timeout(hid_path, buf)
+    _write_to_hid_interface_with_timeout(keyboard_path, buf)
 
     # If it's not a modifier keycode, add a message indicating that the key
     # should be released after it is sent.
     if hid_keycode not in _MODIFIER_KEYCODES:
-        clear(hid_path)
+        release_keys(keyboard_path)
 
 
-def clear(hid_path):
-    _write_to_hid_interface_with_timeout(hid_path, [0] * 8)
+def release_keys(keyboard_path):
+    _write_to_hid_interface_with_timeout(keyboard_path, [0] * 8)

--- a/app/main.py
+++ b/app/main.py
@@ -26,8 +26,8 @@ host = os.environ.get('HOST', '0.0.0.0')
 port = int(os.environ.get('PORT', 8000))
 debug = 'DEBUG' in os.environ
 use_reloader = os.environ.get('USE_RELOADER', '1') == '1'
-# Location of HID file handle in which to write keyboard HID input.
-hid_path = os.environ.get('HID_PATH', '/dev/hidg0')
+# Location of file path at which to write keyboard HID input.
+keyboard_path = os.environ.get('KEYBOARD_PATH', '/dev/hidg0')
 
 app = flask.Flask(__name__, static_url_path='')
 # TODO(mtlynch): Ideally, we wouldn't accept requests from any origin, but the
@@ -69,7 +69,7 @@ def socket_keystroke(message):
         socketio.emit('keystroke-received', {'success': False})
         return
     try:
-        hid.send(hid_path, control_keys, hid_keycode)
+        hid.send_keystroke(keyboard_path, control_keys, hid_keycode)
     except hid.WriteError as e:
         logger.error('Failed to write key: %s (keycode=%d). %s', key_event.key,
                      key_event.key_code, e)
@@ -81,7 +81,7 @@ def socket_keystroke(message):
 @socketio.on('keyRelease')
 def socket_key_release():
     try:
-        hid.clear(hid_path)
+        hid.release_keys(keyboard_path)
     except hid.WriteError as e:
         logger.error('Failed to release keys: %s', e)
 


### PR DESCRIPTION
Refactoring the code to get away from the language of HID as synonymous with keyboard. Mice are also HIDs but operate differently, so we should separate the concept of an HID from the concept of a keyboard.