### PR TITLE
Added SysRq key support for working with hung Linux machines remotely.

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -10,6 +10,7 @@ let manualModifiers = {
   alt: false,
   shift: false,
   ctrl: false,
+  sysrq: false,
 };
 let keystrokeId = 0;
 const processingQueue = [];
@@ -181,7 +182,7 @@ function clearManualModifiers() {
 }
 
 function isModifierKeyCode(keyCode) {
-  const modifierKeyCodes = [16, 17, 18, 91];
+  const modifierKeyCodes = [16, 17, 18, 91, 84];
   return modifierKeyCodes.indexOf(keyCode) >= 0;
 }
 
@@ -243,6 +244,7 @@ function onKeyDown(evt) {
     altKey: evt.altKey || manualModifiers.alt,
     shiftKey: evt.shiftKey || manualModifiers.shift,
     ctrlKey: evt.ctrlKey || manualModifiers.ctrl,
+    sysrqKey: manualModifiers.sysrq,
     key: evt.key,
     keyCode: evt.keyCode,
     location: location,

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -112,6 +112,13 @@
               Shift
             </button>
             <button
+              modifier="sysrq"
+              class="btn manual-modifier-btn"
+              type="button"
+            >
+              SysRq
+            </button>
+            <button
               modifier="meta"
               class="btn manual-modifier-btn"
               type="button"


### PR DESCRIPTION
Unsure on approach to UI changes, but wanted to add support for debugging [Linux servers in known hung states](https://www.kernel.org/doc/html/latest/admin-guide/sysrq.html) remotely.

This addresses feature request: https://github.com/mtlynch/tinypilot/issues/149

Might be worth integrating this into the nav bar better, so other keys (like PrintScr for Windows hosts) can be also added.