### PR TITLE
Rename FUNCTIONS_DIR to KEYBOARD_FUNCTIONS_DIR

### DIFF
--- a/scripts/usb-gadget/init-usb-gadget
+++ b/scripts/usb-gadget/init-usb-gadget
@@ -28,11 +28,11 @@ echo "6b65796d696d6570690" > "${STRINGS_DIR}/serialnumber"
 echo "tinypilot" > "${STRINGS_DIR}/manufacturer"
 echo "Generic USB Keyboard" > "${STRINGS_DIR}/product"
 
-FUNCTIONS_DIR="functions/hid.usb0"
-mkdir -p "$FUNCTIONS_DIR"
-echo 1 > "${FUNCTIONS_DIR}/protocol" # Keyboard
-echo 1 > "${FUNCTIONS_DIR}/subclass" # Boot interface subclass
-echo 8 > "${FUNCTIONS_DIR}/report_length"
+KEYBOARD_FUNCTIONS_DIR="functions/hid.usb0"
+mkdir -p "$KEYBOARD_FUNCTIONS_DIR"
+echo 1 > "${KEYBOARD_FUNCTIONS_DIR}/protocol" # Keyboard
+echo 1 > "${KEYBOARD_FUNCTIONS_DIR}/subclass" # Boot interface subclass
+echo 8 > "${KEYBOARD_FUNCTIONS_DIR}/report_length"
 # Write the report descriptor
 # Source: https://www.kernel.org/doc/html/latest/usb/gadget_hid.html
 KEYBOARD_DESCRIPTOR="\
@@ -41,7 +41,7 @@ KEYBOARD_DESCRIPTOR="\
 \\x75\\x01\\x05\\x08\\x19\\x01\\x29\\x05\\x91\\x02\\x95\\x01\\x75\\x03\\x91\
 \\x03\\x95\\x06\\x75\\x08\\x15\\x00\\x25\\x65\\x05\\x07\\x19\\x00\\x29\\x65\
 \\x81\\x00\\xc0"
-echo -ne "$KEYBOARD_DESCRIPTOR" > "${FUNCTIONS_DIR}/report_desc"
+echo -ne "$KEYBOARD_DESCRIPTOR" > "${KEYBOARD_FUNCTIONS_DIR}/report_desc"
 
 CONFIG_INDEX=1
 CONFIGS_DIR="configs/c.${CONFIG_INDEX}"
@@ -52,7 +52,7 @@ CONFIGS_STRINGS_DIR="${CONFIGS_DIR}/strings/0x409"
 mkdir -p "$CONFIGS_STRINGS_DIR"
 echo "Config ${CONFIG_INDEX}: ECM network" > "${CONFIGS_STRINGS_DIR}/configuration"
 
-ln -s "$FUNCTIONS_DIR" "${CONFIGS_DIR}/"
+ln -s "$KEYBOARD_FUNCTIONS_DIR" "${CONFIGS_DIR}/"
 ls /sys/class/udc > UDC
 
 chmod 777 /dev/hidg0


### PR DESCRIPTION
The init script will eventually support more than one USB gadget function, so this makes the keyboard function explicit as its own function.

Related: #125