### PR TITLE
Refactor connection indicator into custom element

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -41,6 +41,7 @@ if not debug:
     logging.getLogger('engineio').setLevel(logging.ERROR)
 
 app = flask.Flask(__name__, static_url_path='')
+app.config['TEMPLATES_AUTO_RELOAD'] = True
 # TODO(mtlynch): Ideally, we wouldn't accept requests from any origin, but the
 # risk of a CSRF attack for this app is very low. Additionally, CORS doesn't
 # protect us from the dangerous part of a CSRF attack. Even without same-origin

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -158,40 +158,6 @@ button:active {
   cursor: crosshair;
 }
 
-.keyboard-status {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  margin-right: 1rem;
-}
-
-.keyboard-status .status-indicator {
-  display: none;
-  margin-left: 0.8rem;
-}
-
-.keyboard-status .status-dot {
-  height: 14px;
-  width: 14px;
-  border-radius: 50%;
-  display: inline-block;
-}
-
-#status-connected .status-dot {
-  border: 1px solid rgb(190, 255, 170);
-  background-color: rgb(116, 238, 116);
-}
-
-#status-disconnected .status-dot {
-  border: 1px solid rgb(255, 82, 82);
-  background-color: red;
-}
-
-#disconnect-reason {
-  color: red;
-  visibility: hidden;
-}
-
 #keystroke-history {
   display: flex;
   flex-direction: column;

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -79,12 +79,6 @@ function showError(errorType, errorMessage) {
   showElementById("error-panel");
 }
 
-function hideErrorIfType(errorType) {
-  if (document.getElementById("error-type").innerText === errorType) {
-    hideElementById("error-panel");
-  }
-}
-
 function displayPoweringDownUI(restart) {
   for (const elementId of [
     "error-panel",
@@ -209,23 +203,14 @@ function sendKeystroke(keystroke) {
 
 function onSocketConnect() {
   connectedToServer = true;
-  showElementById("status-connected", "flex");
-  hideElementById("status-disconnected");
-
-  hideErrorIfType("Server Connection Error");
+  document.getElementById("connection-indicator").connected = true;
 }
 
 function onSocketDisconnect(reason) {
   connectedToServer = false;
-  hideElementById("status-connected");
-  showElementById("status-disconnected", "flex");
-
-  // If user powered down the device, don't display an error message about
-  // disconnecting from the keyboard service.
-  if (poweringDown) {
-    return;
-  }
-  showError("Server Connection Error", reason);
+  const connectionIndicator = document.getElementById("connection-indicator");
+  connectionIndicator.connected = false;
+  connectionIndicator.disconnectReason = reason;
 }
 
 function onKeyDown(evt) {

--- a/app/templates/components/connection-indicator.html
+++ b/app/templates/components/connection-indicator.html
@@ -1,0 +1,99 @@
+<template id="connection-indicator-template">
+  <style scoped>
+    .status {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      margin-right: 1rem;
+    }
+
+    .status .tooltip {
+      display: flex;
+    }
+
+    .status-dot {
+      height: 1rem;
+      width: 1rem;
+      margin-left: 0.8rem;
+      border-radius: 50%;
+      display: inline-block;
+      /* Disconnected state */
+      border: 1px solid rgb(255, 82, 82);
+      background-color: red;
+    }
+
+    connection-indicator[connected="true"] .status-dot {
+      border: 1px solid rgb(190, 255, 170);
+      background-color: rgb(116, 238, 116);
+    }
+
+    .connected-text {
+      display: none;
+    }
+
+    connection-indicator[connected="true"] .connected-text {
+      display: block;
+    }
+
+    .disconnected-text {
+      display: block;
+    }
+
+    connection-indicator[connected="true"] .disconnected-text {
+      display: none;
+    }
+  </style>
+  <div class="status">
+    <p>Connection</p>
+    <div class="tooltip tooltip-bottom">
+      <span class="status-dot"></span>
+      <div class="tooltip-text">
+        <p class="connected-text">
+          You are connected to TinyPilot.
+        </p>
+        <p class="disconnected-text">
+          Could not connect to TinyPilot:
+          <span id="disconnect-reason"></span>
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+  (function () {
+    const doc = (document._currentScript || document.currentScript)
+      .ownerDocument;
+    const template = doc.querySelector("#connection-indicator-template");
+
+    customElements.define(
+      "connection-indicator",
+      class extends HTMLElement {
+        constructor() {
+          super();
+        }
+
+        connectedCallback() {
+          const temp = document.importNode(template.content, true);
+          this.appendChild(temp);
+        }
+
+        get connected() {
+          return this.getAttribute("connected");
+        }
+
+        set connected(newValue) {
+          this.setAttribute("connected", newValue);
+        }
+
+        get disconnectReason() {
+          return this.querySelector("#disconnect-reason").textContent;
+        }
+
+        set disconnectReason(newValue) {
+          this.querySelector("#disconnect-reason").innerText = newValue;
+        }
+      }
+    );
+  })();
+</script>

--- a/app/templates/components/connection-indicator.html
+++ b/app/templates/components/connection-indicator.html
@@ -1,14 +1,10 @@
 <template id="connection-indicator-template">
-  <style scoped>
+  <style>
     .status {
       display: flex;
       flex-direction: row;
       align-items: center;
       margin-right: 1rem;
-    }
-
-    .status .tooltip {
-      display: flex;
     }
 
     .status-dot {
@@ -22,7 +18,7 @@
       background-color: red;
     }
 
-    connection-indicator[connected="true"] .status-dot {
+    :host([connected="true"]) .status-dot {
       border: 1px solid rgb(190, 255, 170);
       background-color: rgb(116, 238, 116);
     }
@@ -31,7 +27,7 @@
       display: none;
     }
 
-    connection-indicator[connected="true"] .connected-text {
+    :host([connected="true"]) .connected-text {
       display: block;
     }
 
@@ -39,8 +35,37 @@
       display: block;
     }
 
-    connection-indicator[connected="true"] .disconnected-text {
+    :host([connected="true"]) .disconnected-text {
       display: none;
+    }
+
+    /* TODO(mtlynch): Refactor this so we're not duplicating the CSS class from
+        the light DOM. */
+    .tooltip {
+      position: relative;
+      display: inline-block;
+    }
+
+    .tooltip .tooltip-text {
+      visibility: hidden;
+      background-color: rgba(65, 65, 65, 0.85);
+      color: #fff;
+      text-align: center;
+      padding: 0.25rem 1rem;
+      border: 1px solid black;
+      border-radius: 6px;
+      position: absolute;
+      z-index: 1;
+    }
+
+    .tooltip-bottom .tooltip-text {
+      top: 100%;
+      left: 50%;
+      margin-left: -200px;
+    }
+
+    .tooltip:hover .tooltip-text {
+      visibility: visible;
     }
   </style>
   <div class="status">
@@ -74,8 +99,8 @@
         }
 
         connectedCallback() {
-          const temp = document.importNode(template.content, true);
-          this.appendChild(temp);
+          this.attachShadow({ mode: "open" });
+          this.shadowRoot.appendChild(template.content.cloneNode(true));
         }
 
         get connected() {
@@ -87,11 +112,14 @@
         }
 
         get disconnectReason() {
-          return this.querySelector("#disconnect-reason").textContent;
+          return this.shadowRoot.querySelector("#disconnect-reason")
+            .textContent;
         }
 
         set disconnectReason(newValue) {
-          this.querySelector("#disconnect-reason").innerText = newValue;
+          this.shadowRoot.querySelector(
+            "#disconnect-reason"
+          ).innerText = newValue;
         }
       }
     );

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -15,34 +15,17 @@
     <meta name="csrf-token" content="{{ csrf_token() }}" />
   </head>
   <body>
+    {% include "components/connection-indicator.html" %}
     <div id="app">
       <div class="navbar">
         <p class="brand">TinyPilot</p>
         <div class="nav-items">
-          <div class="nav-item keyboard-status">
-            <p>Connection</p>
-            <div class="tooltip tooltip-bottom">
-              <div id="status-connected" class="status-indicator">
-                <span class="status-dot"></span>
-              </div>
-              <div class="tooltip-text">
-                <p>
-                  You are connected to TinyPilot.
-                </p>
-              </div>
-            </div>
-
-            <div class="tooltip tooltip-bottom">
-              <div id="status-disconnected" class="status-indicator">
-                <span class="status-dot"></span>
-              </div>
-              <div class="tooltip-text">
-                <p>
-                  Could not connect to TinyPilot. Try reloading the page.
-                </p>
-              </div>
-            </div>
+          <div class="nav-item">
+            <connection-indicator
+              id="connection-indicator"
+            ></connection-indicator>
           </div>
+
           <div class="nav-item nav-icon source-link">
             <a href="https://github.com/mtlynch/tinypilot">
               <img src="/img/GitHub-Mark-Light-120px-plus.png" />


### PR DESCRIPTION
Rewrite the connection indicator in the navbar as an HTML custom element. In the process, I moved the error reason from a dialog box to the tooltip that displays when the user hovers over a "disconnected" indicator.

![image](https://user-images.githubusercontent.com/7783288/91661110-de67bd00-eaa7-11ea-8b36-709a324fd8af.png)
