### PR TITLE
Remove cruft from content-tooltip

### DIFF
--- a/app/templates/components/content-tooltip.html
+++ b/app/templates/components/content-tooltip.html
@@ -57,25 +57,6 @@
           this.attachShadow({ mode: "open" });
           this.shadowRoot.appendChild(template.content.cloneNode(true));
         }
-
-        get connected() {
-          return this.getAttribute("connected");
-        }
-
-        set connected(newValue) {
-          this.setAttribute("connected", newValue);
-        }
-
-        get disconnectReason() {
-          return this.shadowRoot.querySelector("#disconnect-reason")
-            .textContent;
-        }
-
-        set disconnectReason(newValue) {
-          this.shadowRoot.querySelector(
-            "#disconnect-reason"
-          ).innerText = newValue;
-        }
       }
     );
   })();


### PR DESCRIPTION
I accidentally left it in when copy/pasting the starting code from connection-indicator.