### PR TITLE
Fix edge-case where numbers get parsed as integer

### DIFF
--- a/app/request_parsers/mouse_event.py
+++ b/app/request_parsers/mouse_event.py
@@ -49,7 +49,8 @@ def _parse_button_state(buttons):
 
 
 def _parse_relative_position(relative_position):
-    if type(relative_position) is not float:
+    if type(relative_position) is not float and type(
+            relative_position) is not int:
         raise InvalidRelativePosition(
             'Relative position must be a float between 0.0 and 1.0: %s' %
             relative_position)

--- a/app/tests/request_parsers/test_mouse_event.py
+++ b/app/tests/request_parsers/test_mouse_event.py
@@ -14,6 +14,15 @@ class MouseEventTest(unittest.TestCase):
                 'relativeY': 0.75,
             }))
 
+    def test_parses_valid_mouse_event_with_int_position(self):
+        self.assertEqual(
+            mouse_event.MouseEvent(buttons=1, relative_x=0.0, relative_y=0.75),
+            mouse_event.parse_mouse_event({
+                'buttons': 1,
+                'relativeX': 0,
+                'relativeY': 0.75,
+            }))
+
     def test_parses_valid_mouse_event_with_all_buttons_pressed(self):
         self.assertEqual(
             mouse_event.MouseEvent(buttons=31, relative_x=0.5, relative_y=0.75),


### PR DESCRIPTION
If a number gets sent as `0` (as opposed to `0.0`), the variable ends up as integer.