### PR TITLE
Block mouse events when not connected to server

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -124,6 +124,7 @@ function sendKeystroke(keystroke) {
 function onSocketConnect() {
   connectedToServer = true;
   document.getElementById("connection-indicator").connected = true;
+  //hideElementById("shutdown-dialog");
 }
 
 function onSocketDisconnect(reason) {
@@ -168,6 +169,9 @@ function onKeyDown(evt) {
 }
 
 function sendMouseEvent(evt) {
+  if (!connectedToServer) {
+    return;
+  }
   const boundingRect = evt.target.getBoundingClientRect();
   const cursorX = Math.max(0, evt.clientX - boundingRect.left);
   const cursorY = Math.max(0, evt.clientY - boundingRect.top);
@@ -284,7 +288,7 @@ document
 document
   .getElementById("shutdown-dialog")
   .addEventListener("shutdown-started", (evt) => {
-    displayPoweringDownUI(evt.detail.restart);
+    isplayPoweringDownUI(evt.detail.restart);
   });
 document
   .getElementById("shutdown-dialog")

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -124,7 +124,6 @@ function sendKeystroke(keystroke) {
 function onSocketConnect() {
   connectedToServer = true;
   document.getElementById("connection-indicator").connected = true;
-  //hideElementById("shutdown-dialog");
 }
 
 function onSocketDisconnect(reason) {
@@ -288,7 +287,7 @@ document
 document
   .getElementById("shutdown-dialog")
   .addEventListener("shutdown-started", (evt) => {
-    isplayPoweringDownUI(evt.detail.restart);
+    displayPoweringDownUI(evt.detail.restart);
   });
 document
   .getElementById("shutdown-dialog")


### PR DESCRIPTION
You are blocking mouse down and up, why not also block mouse events when connectedToServer=false.