### PR TITLE
Remove observedAttributes from shutdown-dialog

### DIFF
--- a/app/templates/custom-elements/shutdown-dialog.html
+++ b/app/templates/custom-elements/shutdown-dialog.html
@@ -109,10 +109,6 @@
           this.setAttribute("show", newValue);
         }
 
-        static get observedAttributes() {
-          return ["show"];
-        }
-
         emitShutdownEvent(restart) {
           this.dispatchEvent(
             new CustomEvent("shutdown-started", {


### PR DESCRIPTION
We're not doing anything with the change events, so we don't need to observe.