### PR TITLE
Prevent drag and drop on Firefox

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -266,6 +266,15 @@ screenImg.addEventListener("mouseup", sendMouseEvent);
 screenImg.addEventListener("contextmenu", function (evt) {
   evt.preventDefault();
 });
+const remoteScreenDiv = document.getElementById("remote-screen");
+remoteScreenDiv.addEventListener("dragstart", function (evt) {
+  // Prevent drag on screen for Firefox.
+  evt.preventDefault();
+});
+remoteScreenDiv.addEventListener("drop", function (evt) {
+  // Prevent drop on screen for Firefox.
+  evt.preventDefault();
+});
 document
   .getElementById("display-history-checkbox")
   .addEventListener("change", onDisplayHistoryChanged);


### PR DESCRIPTION
Firefox still have ghost image when drag within tinypilot web UI.

This PR added listener to prevent default behavior on dragstart / drop on the parent remoteScreenDiv. This is what I found work most effectively.