### PR TITLE
Fix Shutdown Wait - Mark Complete

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -102,7 +102,7 @@ function displayPoweringDownUI(restart) {
         shutdownWait.message = "Shutdown complete.";
         shutdownWait.spinner = "none";
       }
-    }, 3000);
+    }, 30 * 1000);
   }
   document.getElementById("shutdown-dialog").show = false;
   document.getElementById("shutdown-wait").show = true;

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -96,6 +96,13 @@ function displayPoweringDownUI(restart) {
     shutdownWait.message = "Restarting TinyPilot Device...";
   } else {
     shutdownWait.message = "Shutting down TinyPilot Device...";
+    setTimeout(() => {
+      const shutdownWait = document.getElementById("shutdown-wait");
+      if (shutdownWait.show) {
+        shutdownWait.message = "Shutdown complete.";
+        shutdownWait.spinner = "none";
+      }
+    }, 3000);
   }
   document.getElementById("shutdown-dialog").show = false;
   document.getElementById("shutdown-wait").show = true;

--- a/app/templates/custom-elements/shutdown-wait.html
+++ b/app/templates/custom-elements/shutdown-wait.html
@@ -84,14 +84,19 @@
         }
 
         get message() {
-          return this.shadowRoot.querySelector("#shutdown-wait-message")
+          return this.shadowRoot.getElementById("shutdown-wait-message")
             .innerText;
         }
 
         set message(newValue) {
-          this.shadowRoot.querySelector(
-            "#shutdown-wait-message"
+          this.shadowRoot.getElementById(
+            "shutdown-wait-message"
           ).innerText = newValue;
+        }
+
+        set spinner(newValue) {
+          return this.shadowRoot.getElementById("shutdown-wait-message")
+            .nextElementSibling.style.display = newValue;
         }
       }
     );


### PR DESCRIPTION
Add a 30 second timer to change the message in the dialog and hide the spinner. Message will only change if the shutdown-wait dialog is still open. That last part might not be necessary since there really is no way to close it. Also this does not disable the socket client, if we are able to reconnect to the tiny pilot device the website will reload.

Fixes #224
