### PR TITLE
Shrink History

### DIFF
--- a/app/static/css/keyboard-panel.css
+++ b/app/static/css/keyboard-panel.css
@@ -14,12 +14,6 @@
   flex-direction: row;
   flex-wrap: wrap;
   min-width: 800px;
-  min-height: 90px;
-  transition: min-height 0.25s ease-in;
-}
-
-#recent-keys[style*="visibility: hidden;"] {
-  min-height: 0px;
 }
 
 .key-card {

--- a/app/static/css/keyboard-panel.css
+++ b/app/static/css/keyboard-panel.css
@@ -13,6 +13,7 @@
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
+  min-height: 90px;
   min-width: 800px;
 }
 

--- a/app/static/css/keyboard-panel.css
+++ b/app/static/css/keyboard-panel.css
@@ -15,6 +15,11 @@
   flex-wrap: wrap;
   min-width: 800px;
   min-height: 90px;
+  transition: min-height 0.25s ease-in;
+}
+
+#recent-keys[style*="visibility: hidden;"] {
+  min-height: 0px;
 }
 
 .key-card {

--- a/app/static/css/keyboard-panel.css
+++ b/app/static/css/keyboard-panel.css
@@ -13,8 +13,13 @@
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  min-height: 90px;
   min-width: 800px;
+  min-height: 90px;
+  transition: min-height 0.25s ease-in;
+}
+
+#recent-keys.hide-keys {
+  min-height: 0px;
 }
 
 .key-card {

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -30,7 +30,9 @@ function showElementById(id, display = "block") {
 }
 
 function shouldDisplayKeyHistory() {
-  return document.getElementById("recent-keys").style.display !== "none";
+  return !document
+    .getElementById("recent-keys")
+    .classList.contains("hide-keys");
 }
 
 // Limit display of recent keys to the last N keys, where limit = N.

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -222,9 +222,9 @@ function onKeyUp(evt) {
 
 function onDisplayHistoryChanged(evt) {
   if (evt.target.checked) {
-    document.getElementById("recent-keys").style.removeProperty("display");
+    document.getElementById("recent-keys").classList.remove("hide-keys");
   } else {
-    document.getElementById("recent-keys").style.display = "none";
+    document.getElementById("recent-keys").classList.add("hide-keys");
     limitRecentKeys(0);
   }
 }

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -30,7 +30,7 @@ function showElementById(id, display = "block") {
 }
 
 function shouldDisplayKeyHistory() {
-  return document.getElementById("recent-keys").style.visibility !== "hidden";
+  return document.getElementById("recent-keys").style.display !== "none";
 }
 
 // Limit display of recent keys to the last N keys, where limit = N.
@@ -222,9 +222,9 @@ function onKeyUp(evt) {
 
 function onDisplayHistoryChanged(evt) {
   if (evt.target.checked) {
-    document.getElementById("recent-keys").style.visibility = "visible";
+    document.getElementById("recent-keys").style.removeProperty("display");
   } else {
-    document.getElementById("recent-keys").style.visibility = "hidden";
+    document.getElementById("recent-keys").style.display = "none";
     limitRecentKeys(0);
   }
 }


### PR DESCRIPTION
Hiding the history now frees up that 90px of screen real-estate it was using. This helps keep the modifier key buttons in view by preventing overflow.