### PR TITLE
Fix write exception 'Resource temporarily unavailable'

### DIFF
--- a/app/hid/write.py
+++ b/app/hid/write.py
@@ -12,7 +12,7 @@ class WriteError(Error):
 def write_to_hid_interface(hid_path, buffer):
     hid_fd = 0
     try:
-        hid_fd = os.open(hid_path, os.O_RDWR | os.O_NONBLOCK)
+        hid_fd = os.open(hid_path, os.O_RDWR)
         os.write(hid_fd, bytearray(buffer))
     except BlockingIOError:
         raise WriteError(


### PR DESCRIPTION
Fixes 'Resource temporarily unavailable' exceptions when writing too quickly to the hid interface