### PR TITLE
Consolidate key press and release writes to HID interface

### DIFF
--- a/app/hid/keyboard.py
+++ b/app/hid/keyboard.py
@@ -15,13 +15,9 @@ def send_keystroke(keyboard_path, control_keys, hid_keycode):
     buf = [0] * 8
     buf[0] = control_keys
     buf[2] = hid_keycode
-    hid_write.write_to_hid_interface(keyboard_path, buf)
 
     # If it's not a modifier keycode, add a message indicating that the key
     # should be released after it is sent.
     if hid_keycode not in _MODIFIER_KEYCODES:
-        release_keys(keyboard_path)
-
-
-def release_keys(keyboard_path):
-    hid_write.write_to_hid_interface(keyboard_path, [0] * 8)
+        buf += [0] * 8
+    hid_write.write_to_hid_interface(keyboard_path, buf)


### PR DESCRIPTION
If we do them as separate writes and the second write fails, we end up in a situation where the key gets stuck pressed down.