### PR TITLE
Revert "Add a comment explaining why we open the HID interface as O_NONBLOCK"

### DIFF
--- a/app/hid/write.py
+++ b/app/hid/write.py
@@ -12,9 +12,6 @@ class WriteError(Error):
 def write_to_hid_interface(hid_path, buffer):
     hid_fd = 0
     try:
-        # Open the HID interface in non-blocking mode. Otherwise, if the write
-        # fails, for example due to a cable that's incompatible or broken, the
-        # write will hang indefinitely, locking up the process.
         hid_fd = os.open(hid_path, os.O_RDWR | os.O_NONBLOCK)
         os.write(hid_fd, bytearray(buffer))
     except BlockingIOError:


### PR DESCRIPTION
Reverts mtlynch/tinypilot#251

We don't actually need to do O_NONBLOCK, as it will time out normally.