### PR TITLE
Use regular open() function to write to the HID interface

### DIFF
--- a/app/hid/write.py
+++ b/app/hid/write.py
@@ -12,4 +12,5 @@ def write_to_hid_interface(hid_path, buffer):
             hid_interface.write(bytearray(buffer))
     except BlockingIOError:
         raise WriteError(
-            'Failed to write to HID interface. Is USB cable connected?')
+            'Failed to write to HID interface: %s. Is USB cable connected?' %
+            hid_path)

--- a/app/hid/write.py
+++ b/app/hid/write.py
@@ -1,6 +1,3 @@
-import os
-
-
 class Error(Exception):
     pass
 
@@ -10,13 +7,9 @@ class WriteError(Error):
 
 
 def write_to_hid_interface(hid_path, buffer):
-    hid_fd = 0
     try:
-        hid_fd = os.open(hid_path, os.O_RDWR)
-        os.write(hid_fd, bytearray(buffer))
+        with open(hid_path, 'rb+') as hid_interface:
+            hid_interface.write(bytearray(buffer))
     except BlockingIOError:
         raise WriteError(
             'Failed to write to HID interface. Is USB cable connected?')
-    finally:
-        if hid_fd:
-            os.close(hid_fd)

--- a/app/hid/write.py
+++ b/app/hid/write.py
@@ -8,7 +8,7 @@ class WriteError(Error):
 
 def write_to_hid_interface(hid_path, buffer):
     try:
-        with open(hid_path, 'rb+') as hid_interface:
+        with open(hid_path, 'wb+') as hid_interface:
             hid_interface.write(bytearray(buffer))
     except BlockingIOError:
         raise WriteError(


### PR DESCRIPTION
I initially switched to os.open because I thought we needed to O_NONBLOCK flag, but given that it's unnecessary, we can go back to the regular file open API.