### PR TITLE
Drop keystroke-received socket event

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -73,22 +73,19 @@ def socket_keystroke(message):
     except js_to_hid.UnrecognizedKeyCodeError:
         logger.warning('Unrecognized key: %s (keycode=%d)', keystroke.key,
                        keystroke.key_code)
-        socketio.emit('keystroke-received', processing_result)
-        return
+        return processing_result
     if hid_keycode is None:
         logger.info('Ignoring %s key (keycode=%d)', keystroke.key,
                     keystroke.key_code)
-        socketio.emit('keystroke-received', processing_result)
-        return
+        return processing_result
     try:
         fake_keyboard.send_keystroke(keyboard_path, control_keys, hid_keycode)
     except hid_write.WriteError as e:
         logger.error('Failed to write key: %s (keycode=%d). %s', keystroke.key,
                      keystroke.key_code, e)
-        socketio.emit('keystroke-received', processing_result)
-        return
+        return processing_result
     processing_result['success'] = True
-    socketio.emit('keystroke-received', processing_result)
+    return processing_result
 
 
 @socketio.on('mouse-event')

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -141,7 +141,9 @@ function sendKeystroke(keystroke) {
   if (!keystroke.metaKey) {
     addKeyCard(keystroke.key, keystroke.id);
   }
-  socket.emit("keystroke", keystroke);
+  socket.emit("keystroke", keystroke, (result) => {
+    updateKeyStatus(result.keystrokeId, result.success);
+  });
   if (!keystroke.metaKey) {
     // Increment the global keystroke ID.
     keystrokeId++;
@@ -373,6 +375,3 @@ for (const cursorOption of screenCursorOptions.splice(1)) {
 }
 socket.on("connect", onSocketConnect);
 socket.on("disconnect", onSocketDisconnect);
-socket.on("keystroke-received", (keystrokeResult) => {
-  updateKeyStatus(keystrokeResult.keystrokeId, keystrokeResult.success);
-});


### PR DESCRIPTION
I didn't realize we can just handle it in the .emit() response parameter.