### PR TITLE
Refactor out keystrokeId

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -66,26 +66,24 @@ def socket_keystroke(message):
         logger.error('Failed to parse keystroke request: %s', e)
         return
     hid_keycode = None
-    processing_result = {'keystrokeId': keystroke.id, 'success': False}
     try:
         control_keys, hid_keycode = js_to_hid.convert(keystroke,
                                                       keyboard_layout)
     except js_to_hid.UnrecognizedKeyCodeError:
         logger.warning('Unrecognized key: %s (keycode=%d)', keystroke.key,
                        keystroke.key_code)
-        return processing_result
+        return {'success': False}
     if hid_keycode is None:
         logger.info('Ignoring %s key (keycode=%d)', keystroke.key,
                     keystroke.key_code)
-        return processing_result
+        return {'success': False}
     try:
         fake_keyboard.send_keystroke(keyboard_path, control_keys, hid_keycode)
     except hid_write.WriteError as e:
         logger.error('Failed to write key: %s (keycode=%d). %s', keystroke.key,
                      keystroke.key_code, e)
-        return processing_result
-    processing_result['success'] = True
-    return processing_result
+        return {'success': False}
+    return {'success': True}
 
 
 @socketio.on('mouse-event')

--- a/app/request_parsers/keystroke.py
+++ b/app/request_parsers/keystroke.py
@@ -19,7 +19,6 @@ class InvalidKeyCode(Error):
 
 @dataclasses.dataclass
 class Keystroke:
-    id: int
     left_ctrl_modifier: bool
     left_shift_modifier: bool
     left_alt_modifier: bool
@@ -34,7 +33,6 @@ def parse_keystroke(message):
         raise MissingField(
             'Keystroke parameter is invalid, expecting a dictionary data type')
     required_fields = (
-        'id',
         'key',
         'keyCode',
         'ctrlKey',
@@ -48,7 +46,6 @@ def parse_keystroke(message):
             raise MissingField(
                 'Keystroke request is missing required field: %s' % field)
     return Keystroke(
-        id=message['id'],
         left_ctrl_modifier=_parse_modifier_key(message['ctrlKey']),
         left_shift_modifier=_parse_modifier_key(message['shiftKey']),
         left_alt_modifier=_parse_modifier_key(message['altKey']),

--- a/app/tests/request_parsers/test_keystroke.py
+++ b/app/tests/request_parsers/test_keystroke.py
@@ -17,8 +17,7 @@ class KeystrokeTest(unittest.TestCase):
 
     def test_parses_valid_keystroke_message(self):
         self.assertEqual(
-            keystroke.Keystroke(id=123,
-                                left_meta_modifier=False,
+            keystroke.Keystroke(left_meta_modifier=False,
                                 left_alt_modifier=False,
                                 left_shift_modifier=False,
                                 left_ctrl_modifier=False,
@@ -26,7 +25,6 @@ class KeystrokeTest(unittest.TestCase):
                                 key='A',
                                 key_code=65),
             keystroke.parse_keystroke({
-                'id': 123,
                 'metaKey': False,
                 'altKey': False,
                 'shiftKey': False,
@@ -38,8 +36,7 @@ class KeystrokeTest(unittest.TestCase):
 
     def test_parses_valid_keystroke_message_with_all_modifiers_pushed(self):
         self.assertEqual(
-            keystroke.Keystroke(id=456,
-                                left_meta_modifier=True,
+            keystroke.Keystroke(left_meta_modifier=True,
                                 left_alt_modifier=True,
                                 left_shift_modifier=True,
                                 left_ctrl_modifier=True,
@@ -47,7 +44,6 @@ class KeystrokeTest(unittest.TestCase):
                                 key='A',
                                 key_code=65),
             keystroke.parse_keystroke({
-                'id': 456,
                 'metaKey': True,
                 'altKey': True,
                 'shiftKey': True,
@@ -60,7 +56,6 @@ class KeystrokeTest(unittest.TestCase):
     def test_rejects_invalid_meta_modifier(self):
         with self.assertRaises(keystroke.InvalidModifierKey):
             keystroke.parse_keystroke({
-                'id': 123,
                 'metaKey': 'banana',
                 'altKey': False,
                 'shiftKey': False,
@@ -73,7 +68,6 @@ class KeystrokeTest(unittest.TestCase):
     def test_rejects_invalid_alt_modifier(self):
         with self.assertRaises(keystroke.InvalidModifierKey):
             keystroke.parse_keystroke({
-                'id': 123,
                 'metaKey': False,
                 'altKey': 'banana',
                 'shiftKey': False,
@@ -86,7 +80,6 @@ class KeystrokeTest(unittest.TestCase):
     def test_rejects_invalid_shift_modifier(self):
         with self.assertRaises(keystroke.InvalidModifierKey):
             keystroke.parse_keystroke({
-                'id': 123,
                 'metaKey': False,
                 'altKey': False,
                 'shiftKey': 'banana',
@@ -99,7 +92,6 @@ class KeystrokeTest(unittest.TestCase):
     def test_rejects_invalid_ctrl_modifier(self):
         with self.assertRaises(keystroke.InvalidModifierKey):
             keystroke.parse_keystroke({
-                'id': 123,
                 'metaKey': False,
                 'altKey': False,
                 'shiftKey': False,
@@ -112,7 +104,6 @@ class KeystrokeTest(unittest.TestCase):
     def test_rejects_invalid_alt_graph_modifier(self):
         with self.assertRaises(keystroke.InvalidModifierKey):
             keystroke.parse_keystroke({
-                'id': 123,
                 'metaKey': False,
                 'altKey': False,
                 'shiftKey': False,
@@ -125,7 +116,6 @@ class KeystrokeTest(unittest.TestCase):
     def test_rejects_negative_keycode_value(self):
         with self.assertRaises(keystroke.InvalidKeyCode):
             keystroke.parse_keystroke({
-                'id': 123,
                 'metaKey': False,
                 'altKey': False,
                 'shiftKey': False,
@@ -138,7 +128,6 @@ class KeystrokeTest(unittest.TestCase):
     def test_rejects_too_high_keycode_value(self):
         with self.assertRaises(keystroke.InvalidKeyCode):
             keystroke.parse_keystroke({
-                'id': 123,
                 'metaKey': False,
                 'altKey': False,
                 'shiftKey': False,
@@ -151,7 +140,6 @@ class KeystrokeTest(unittest.TestCase):
     def test_rejects_string_keycode_value(self):
         with self.assertRaises(keystroke.InvalidKeyCode):
             keystroke.parse_keystroke({
-                'id': 123,
                 'metaKey': False,
                 'altKey': False,
                 'shiftKey': False,
@@ -164,7 +152,6 @@ class KeystrokeTest(unittest.TestCase):
     def test_rejects_float_keycode_value(self):
         with self.assertRaises(keystroke.InvalidKeyCode):
             keystroke.parse_keystroke({
-                'id': 123,
                 'metaKey': False,
                 'altKey': False,
                 'shiftKey': False,
@@ -174,22 +161,9 @@ class KeystrokeTest(unittest.TestCase):
                 'keyCode': 1.25,
             })
 
-    def test_rejects_missing_id_value(self):
-        with self.assertRaises(keystroke.MissingField):
-            keystroke.parse_keystroke({
-                'metaKey': False,
-                'altKey': False,
-                'shiftKey': False,
-                'ctrlKey': False,
-                'altGraphKey': False,
-                'key': 'A',
-                'keyCode': 1,
-            })
-
     def test_rejects_missing_meta_key_value(self):
         with self.assertRaises(keystroke.MissingField):
             keystroke.parse_keystroke({
-                'id': 123,
                 'altKey': False,
                 'shiftKey': False,
                 'ctrlKey': False,
@@ -201,7 +175,6 @@ class KeystrokeTest(unittest.TestCase):
     def test_rejects_missing_alt_key_value(self):
         with self.assertRaises(keystroke.MissingField):
             keystroke.parse_keystroke({
-                'id': 123,
                 'metaKey': False,
                 'shiftKey': False,
                 'ctrlKey': False,
@@ -213,7 +186,6 @@ class KeystrokeTest(unittest.TestCase):
     def test_rejects_missing_alt_graph_key_value(self):
         with self.assertRaises(keystroke.MissingField):
             keystroke.parse_keystroke({
-                'id': 123,
                 'altKey': False,
                 'metaKey': False,
                 'shiftKey': False,
@@ -225,7 +197,6 @@ class KeystrokeTest(unittest.TestCase):
     def test_rejects_missing_shift_key_value(self):
         with self.assertRaises(keystroke.MissingField):
             keystroke.parse_keystroke({
-                'id': 123,
                 'metaKey': False,
                 'altKey': False,
                 'ctrlKey': False,
@@ -237,7 +208,6 @@ class KeystrokeTest(unittest.TestCase):
     def test_rejects_missing_ctrl_key_value(self):
         with self.assertRaises(keystroke.MissingField):
             keystroke.parse_keystroke({
-                'id': 123,
                 'metaKey': False,
                 'altKey': False,
                 'shiftKey': False,
@@ -249,7 +219,6 @@ class KeystrokeTest(unittest.TestCase):
     def test_rejects_missing_key_value(self):
         with self.assertRaises(keystroke.MissingField):
             keystroke.parse_keystroke({
-                'id': 123,
                 'metaKey': False,
                 'altKey': False,
                 'shiftKey': False,
@@ -261,7 +230,6 @@ class KeystrokeTest(unittest.TestCase):
     def test_rejects_missing_key_code_value(self):
         with self.assertRaises(keystroke.MissingField):
             keystroke.parse_keystroke({
-                'id': 123,
                 'metaKey': False,
                 'altKey': False,
                 'shiftKey': False,


### PR DESCRIPTION
Using socket.io's callbacks, we don't really need to track keystroke IDs, so this removes them.