### PR TITLE
Fix Error parsing viewport meta content

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -14,7 +14,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, maximum-scale=1; scalable=no;"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
     />
     <meta name="csrf-token" content="{{ csrf_token() }}" />
   </head>


### PR DESCRIPTION
Fix `Error parsing a meta element's content: ';' is not a valid key-value pair separator. Please use ',' instead.` and `The key "scalable" is not recognized and ignored.`

Note: The `user-scalable` disabled browser zoom on mobile. You may or may not want that, it is up to you.