### PR TITLE
Expand remote screen real estate when browser window is small

### DIFF
--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -7,9 +7,39 @@
     }
 
     #remote-screen-img {
-      max-width: 85%;
+      max-width: 100%;
       max-height: 1080px;
       object-fit: contain;
+    }
+
+    @media screen and (min-width: 800px) {
+      #remote-screen-img {
+        max-width: 99%;
+      }
+    }
+
+    @media screen and (min-width: 1000px) {
+      #remote-screen-img {
+        max-width: 97%;
+      }
+    }
+
+    @media screen and (min-width: 1200px) {
+      #remote-screen-img {
+        max-width: 96%;
+      }
+    }
+
+    @media screen and (min-width: 1300px) {
+      #remote-screen-img {
+        max-width: 93%;
+      }
+    }
+
+    @media screen and (min-width: 1400px) {
+      #remote-screen-img {
+        max-width: 90%;
+      }
     }
 
     :host([fullscreen="true"]) .screen-wrapper {


### PR DESCRIPTION
Adjust the CSS rules for the remote screen image so that its margins reduce the smaller the screen is.

### Before

![resize-old](https://user-images.githubusercontent.com/7783288/94736851-e468ec00-033a-11eb-8dca-4d8452bbdc78.gif)

### After

![resize-new](https://user-images.githubusercontent.com/7783288/94736616-84724580-033a-11eb-8e0f-e436dc98e1dc.gif)