### PR TITLE
Switching keycodes.js and app.js to ES6 modules

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -1,5 +1,7 @@
 "use strict";
 
+import { isAltGraphPressed, findKeyCode } from "./keycodes.js";
+
 const socket = io();
 let connectedToServer = false;
 

--- a/app/static/js/keycodes.js
+++ b/app/static/js/keycodes.js
@@ -66,7 +66,7 @@ const commonKeyCodes = {
 };
 
 // Given a character and a browser language, finds the matching keycode
-function findKeyCode(character, browserLanguage) {
+export function findKeyCode(character, browserLanguage) {
   if (browserLanguage === "en-GB") {
     return findKeyCodeEnGb(character);
   }
@@ -127,7 +127,7 @@ function findKeyCodeEnGb(character) {
 // But in my tests, I see all modifiers as false when Alt Graph is pushed.
 // The only difference in the onKeyDown event I see is that the key property
 // changes when Alt Graph is pushed, so we detect it that way.
-function isAltGraphPressed(browserLanguage, keyCode, key) {
+export function isAltGraphPressed(browserLanguage, keyCode, key) {
   // Only French AZERTY is supported now.
   // This is not robust, as a user's browser language doesn't necessarily match
   // their keyboard layout.

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -47,8 +47,7 @@
     {% include "components/paste-overlay.html" %}
     <shutdown-wait id="shutdown-wait"></shutdown-wait>
     <script src="/third-party/socket.io/2.3.0/socket.io.js"></script>
-    <script src="/js/keycodes.js"></script>
     <script src="/js/paste.js"></script>
-    <script src="/js/app.js"></script>
+    <script type="module" src="/js/app.js"></script>
   </body>
 </html>


### PR DESCRIPTION
This avoids polluting the global namespace and makes explicit which functions we want to export.