### PR TITLE
Move input to top to prevent scroll down on mobile when keyboard is activated.

### DIFF
--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -63,7 +63,7 @@
 
     #mobile-keyboard-input {
       position: fixed;
-      bottom: -1000px;
+      top: -1000px;
     }
   </style>
   <div class="screen-wrapper">


### PR DESCRIPTION
Fix Mobile scroll down when keyboard is opened.