### PR TITLE
Add support for right modifier keys

### DIFF
--- a/app/js_to_hid.py
+++ b/app/js_to_hid.py
@@ -17,7 +17,7 @@ class InvalidKeyboardLayout(Error):
 
 def convert(keystroke, keyboard_layout_string):
     keycode_mapping = _get_keycode_mapping(keyboard_layout_string,
-                                           keystroke.is_left_modifier)
+                                           keystroke.is_right_modifier)
     try:
         return _map_modifier_keys(keystroke), keycode_mapping[
             keystroke.key_code]
@@ -26,12 +26,12 @@ def convert(keystroke, keyboard_layout_string):
                                        (keystroke.key, keystroke.key_code))
 
 
-def _get_keycode_mapping(keyboard_layout_string, is_left_modifier):
+def _get_keycode_mapping(keyboard_layout_string, is_right_modifier):
     layout = _get_target_keyboard_layout(keyboard_layout_string)
 
     # Use a shorter variable name to avoid screwing up the nice dict format
     # below.
-    left = is_left_modifier
+    right = is_right_modifier
 
     # JS keycodes source: https://github.com/wesbos/keycodes
     return {
@@ -40,9 +40,9 @@ def _get_keycode_mapping(keyboard_layout_string, is_left_modifier):
         9: layout.KEYCODE_TAB,
         12: layout.KEYCODE_CLEAR,
         13: layout.KEYCODE_ENTER,
-        16: layout.KEYCODE_LEFT_SHIFT if left else layout.KEYCODE_RIGHT_SHIFT,
-        17: layout.KEYCODE_LEFT_CTRL if left else layout.KEYCODE_RIGHT_CTRL,
-        18: layout.KEYCODE_LEFT_ALT if left else layout.KEYCODE_RIGHT_CTRL,
+        16: layout.KEYCODE_RIGHT_SHIFT if right else layout.KEYCODE_LEFT_SHIFT,
+        17: layout.KEYCODE_RIGHT_CTRL if right else layout.KEYCODE_LEFT_CTRL,
+        18: layout.KEYCODE_RIGHT_ALT if right else layout.KEYCODE_LEFT_CTRL,
         19: layout.KEYCODE_PAUSE_BREAK,
         20: layout.KEYCODE_CAPS_LOCK,
         21: layout.KEYCODE_HANGEUL,
@@ -103,7 +103,7 @@ def _get_keycode_mapping(keyboard_layout_string, is_left_modifier):
         88: layout.KEYCODE_X,
         89: layout.KEYCODE_Y,
         90: layout.KEYCODE_Z,
-        91: layout.KEYCODE_LEFT_META if left else layout.KEYCODE_RIGHT_META,
+        91: layout.KEYCODE_RIGHT_META if right else layout.KEYCODE_LEFT_META,
         93: layout.KEYCODE_CONTEXT_MENU,
         94: layout.KEYCODE_NUMPAD_4,  # / (UK)
         96: layout.KEYCODE_NUMPAD_0,

--- a/app/js_to_hid.py
+++ b/app/js_to_hid.py
@@ -25,23 +25,23 @@ def convert(keystroke, keyboard_layout_string):
                                        (keystroke.key, keystroke.key_code))
 
 
-def _get_keycode_mapping(keyboard_layout_string):
+def _get_keycode_mapping(keyboard_layout_string, is_left_modifier):
     layout = _get_target_keyboard_layout(keyboard_layout_string)
 
-    # JS keycodes source: https://github.com/wesbos/keycodes
+    # Use a shorter variable name to avoid screwing up the nice dict format
+    # below.
+    left = is_left_modifier
 
-    # TODO: For simplicity, we map all modifiers keys to the left key, but we
-    # could support distinct keys for left and right if we check the location
-    # parameter from the JavaScript message.
+    # JS keycodes source: https://github.com/wesbos/keycodes
     return {
         3: layout.KEYCODE_PAUSE_BREAK,
         8: layout.KEYCODE_BACKSPACE_DELETE,
         9: layout.KEYCODE_TAB,
         12: layout.KEYCODE_CLEAR,
         13: layout.KEYCODE_ENTER,
-        16: layout.KEYCODE_LEFT_SHIFT,
-        17: layout.KEYCODE_LEFT_CTRL,
-        18: layout.KEYCODE_LEFT_ALT,
+        16: layout.KEYCODE_LEFT_SHIFT if left else layout.KEYCODE_RIGHT_SHIFT,
+        17: layout.KEYCODE_LEFT_CTRL if left else layout.KEYCODE_RIGHT_CTRL,
+        18: layout.KEYCODE_LEFT_ALT if left else layout.KEYCODE_RIGHT_CTRL,
         19: layout.KEYCODE_PAUSE_BREAK,
         20: layout.KEYCODE_CAPS_LOCK,
         21: layout.KEYCODE_HANGEUL,
@@ -102,7 +102,7 @@ def _get_keycode_mapping(keyboard_layout_string):
         88: layout.KEYCODE_X,
         89: layout.KEYCODE_Y,
         90: layout.KEYCODE_Z,
-        91: layout.KEYCODE_LEFT_META,
+        91: layout.KEYCODE_LEFT_META if left else layout.KEYCODE_RIGHT_META,
         93: layout.KEYCODE_CONTEXT_MENU,
         94: layout.KEYCODE_NUMPAD_4,  # / (UK)
         96: layout.KEYCODE_NUMPAD_0,

--- a/app/js_to_hid.py
+++ b/app/js_to_hid.py
@@ -186,6 +186,21 @@ def _get_target_keyboard_layout(keyboard_layout_string):
 def _map_modifier_keys(keystroke):
     modifier_bitmask = 0
 
+    # HACK: Because JavaScript's keydown event doesn't indicate left or right
+    # modifier unless it's the only key pressed, we special case it so that if
+    # we see is_right_modifier set to true, we assume it's not a key
+    # combination, but rather a modifier key in isolation, so we set only that
+    # one modifier key.
+    if keystroke.is_right_modifier:
+        if keystroke.left_ctrl_modifier:
+            return modifiers.RIGHT_CTRL
+        elif keystroke.left_shift_modifier:
+            return modifiers.RIGHT_SHIFT
+        elif keystroke.left_alt_modifier:
+            return modifiers.RIGHT_ALT
+        elif keystroke.left_meta_modifier:
+            return modifiers.RIGHT_META
+
     if keystroke.left_ctrl_modifier:
         modifier_bitmask |= modifiers.LEFT_CTRL
     if keystroke.left_shift_modifier:
@@ -196,6 +211,5 @@ def _map_modifier_keys(keystroke):
         modifier_bitmask |= modifiers.LEFT_META
     if keystroke.right_alt_modifier:
         modifier_bitmask |= modifiers.RIGHT_ALT
-    # We currently don't support right ctrl, right shift, or right meta.
 
     return modifier_bitmask

--- a/app/js_to_hid.py
+++ b/app/js_to_hid.py
@@ -16,7 +16,8 @@ class InvalidKeyboardLayout(Error):
 
 
 def convert(keystroke, keyboard_layout_string):
-    keycode_mapping = _get_keycode_mapping(keyboard_layout_string)
+    keycode_mapping = _get_keycode_mapping(keyboard_layout_string,
+                                           keystroke.is_left_modifier)
     try:
         return _map_modifier_keys(keystroke), keycode_mapping[
             keystroke.key_code]

--- a/app/js_to_hid.py
+++ b/app/js_to_hid.py
@@ -42,7 +42,7 @@ def _get_keycode_mapping(keyboard_layout_string, is_right_modifier):
         13: layout.KEYCODE_ENTER,
         16: layout.KEYCODE_RIGHT_SHIFT if right else layout.KEYCODE_LEFT_SHIFT,
         17: layout.KEYCODE_RIGHT_CTRL if right else layout.KEYCODE_LEFT_CTRL,
-        18: layout.KEYCODE_RIGHT_ALT if right else layout.KEYCODE_LEFT_CTRL,
+        18: layout.KEYCODE_RIGHT_ALT if right else layout.KEYCODE_LEFT_ALT,
         19: layout.KEYCODE_PAUSE_BREAK,
         20: layout.KEYCODE_CAPS_LOCK,
         21: layout.KEYCODE_HANGEUL,

--- a/app/request_parsers/keystroke.py
+++ b/app/request_parsers/keystroke.py
@@ -30,7 +30,7 @@ class Keystroke:
     right_alt_modifier: bool
     key: str
     key_code: int
-    is_left_modifier: bool
+    is_right_modifier: bool
 
 
 def parse_keystroke(message):
@@ -59,7 +59,7 @@ def parse_keystroke(message):
         right_alt_modifier=_parse_modifier_key(message['altGraphKey']),
         key=message['key'],
         key_code=_parse_key_code(message['keyCode']),
-        is_left_modifier=_parse_is_left_key_location(message['location']))
+        is_right_modifier=_parse_is_right_key_location(message['location']))
 
 
 def _parse_modifier_key(modifier_key):
@@ -78,13 +78,13 @@ def _parse_key_code(key_code):
     return key_code
 
 
-def _parse_is_left_key_location(location):
+def _parse_is_right_key_location(location):
     if location is None:
         return False
     if type(location) is not str:
         raise InvalidLocation('Location must be "left", "right", or null.')
     elif location.lower() == 'left':
-        return True
-    elif location.lower() == 'right':
         return False
+    elif location.lower() == 'right':
+        return True
     raise InvalidLocation('Location must be "left", "right", or null.')

--- a/app/request_parsers/keystroke.py
+++ b/app/request_parsers/keystroke.py
@@ -17,6 +17,10 @@ class InvalidKeyCode(Error):
     pass
 
 
+class InvalidLocation(Error):
+    pass
+
+
 @dataclasses.dataclass
 class Keystroke:
     left_ctrl_modifier: bool
@@ -26,6 +30,7 @@ class Keystroke:
     right_alt_modifier: bool
     key: str
     key_code: int
+    is_left_modifier: bool
 
 
 def parse_keystroke(message):
@@ -35,6 +40,7 @@ def parse_keystroke(message):
     required_fields = (
         'key',
         'keyCode',
+        'location',
         'ctrlKey',
         'shiftKey',
         'altKey',
@@ -52,7 +58,8 @@ def parse_keystroke(message):
         left_meta_modifier=_parse_modifier_key(message['metaKey']),
         right_alt_modifier=_parse_modifier_key(message['altGraphKey']),
         key=message['key'],
-        key_code=_parse_key_code(message['keyCode']))
+        key_code=_parse_key_code(message['keyCode']),
+        is_left_modifier=_parse_is_left_key_location(message['location']))
 
 
 def _parse_modifier_key(modifier_key):
@@ -69,3 +76,15 @@ def _parse_key_code(key_code):
         raise InvalidKeyCode('Key code must be between 0x00 and 0xff: %d',
                              key_code)
     return key_code
+
+
+def _parse_is_left_key_location(location):
+    if location is None:
+        return False
+    if type(location) is not str:
+        raise InvalidLocation('Location must be "left", "right", or null.')
+    elif location.lower() == 'left':
+        return True
+    elif location.lower() == 'right':
+        return False
+    raise InvalidLocation('Location must be "left", "right", or null.')

--- a/app/tests/request_parsers/test_keystroke.py
+++ b/app/tests/request_parsers/test_keystroke.py
@@ -18,7 +18,7 @@ class KeystrokeTest(unittest.TestCase):
                                 right_alt_modifier=False,
                                 key='A',
                                 key_code=65,
-                                is_left_modifier=False),
+                                is_right_modifier=False),
             keystroke.parse_keystroke({
                 'metaKey': False,
                 'altKey': False,
@@ -39,7 +39,7 @@ class KeystrokeTest(unittest.TestCase):
                                 right_alt_modifier=True,
                                 key='A',
                                 key_code=65,
-                                is_left_modifier=False),
+                                is_right_modifier=False),
             keystroke.parse_keystroke({
                 'metaKey': True,
                 'altKey': True,
@@ -60,7 +60,7 @@ class KeystrokeTest(unittest.TestCase):
                                 right_alt_modifier=False,
                                 key='Control',
                                 key_code=17,
-                                is_left_modifier=True),
+                                is_right_modifier=False),
             keystroke.parse_keystroke({
                 'metaKey': False,
                 'altKey': False,
@@ -84,7 +84,7 @@ class KeystrokeTest(unittest.TestCase):
                 right_alt_modifier=False,
                 key='Control',
                 key_code=17,
-                is_left_modifier=False),
+                is_right_modifier=True),
             keystroke.parse_keystroke({
                 'metaKey': False,
                 'altKey': False,

--- a/app/tests/request_parsers/test_keystroke.py
+++ b/app/tests/request_parsers/test_keystroke.py
@@ -5,15 +5,20 @@ from request_parsers import keystroke
 
 class KeystrokeTest(unittest.TestCase):
 
+    def assertKeystrokesEqual(self, expected, actual):
+        if expected != actual:
+            raise AssertionError('%s != %s' % (expected, actual))
+
     def test_parses_valid_keystroke_message(self):
-        self.assertEqual(
+        self.assertKeystrokesEqual(
             keystroke.Keystroke(left_meta_modifier=False,
                                 left_alt_modifier=False,
                                 left_shift_modifier=False,
                                 left_ctrl_modifier=False,
                                 right_alt_modifier=False,
                                 key='A',
-                                key_code=65),
+                                key_code=65,
+                                is_left_modifier=False),
             keystroke.parse_keystroke({
                 'metaKey': False,
                 'altKey': False,
@@ -22,17 +27,19 @@ class KeystrokeTest(unittest.TestCase):
                 'altGraphKey': False,
                 'key': 'A',
                 'keyCode': 65,
+                'location': None,
             }))
 
     def test_parses_valid_keystroke_message_with_all_modifiers_pushed(self):
-        self.assertEqual(
+        self.assertKeystrokesEqual(
             keystroke.Keystroke(left_meta_modifier=True,
                                 left_alt_modifier=True,
                                 left_shift_modifier=True,
                                 left_ctrl_modifier=True,
                                 right_alt_modifier=True,
                                 key='A',
-                                key_code=65),
+                                key_code=65,
+                                is_left_modifier=False),
             keystroke.parse_keystroke({
                 'metaKey': True,
                 'altKey': True,
@@ -41,6 +48,52 @@ class KeystrokeTest(unittest.TestCase):
                 'altGraphKey': True,
                 'key': 'A',
                 'keyCode': 65,
+                'location': None,
+            }))
+
+    def test_parses_left_ctrl_key(self):
+        self.assertKeystrokesEqual(
+            keystroke.Keystroke(left_meta_modifier=False,
+                                left_alt_modifier=False,
+                                left_shift_modifier=False,
+                                left_ctrl_modifier=True,
+                                right_alt_modifier=False,
+                                key='Control',
+                                key_code=17,
+                                is_left_modifier=True),
+            keystroke.parse_keystroke({
+                'metaKey': False,
+                'altKey': False,
+                'shiftKey': False,
+                'ctrlKey': True,
+                'altGraphKey': False,
+                'key': 'Control',
+                'keyCode': 17,
+                'location': 'left',
+            }))
+
+    def test_parses_right_ctrl_key(self):
+        self.assertKeystrokesEqual(
+            keystroke.Keystroke(
+                left_meta_modifier=False,
+                left_alt_modifier=False,
+                left_shift_modifier=False,
+                # For simplicity, we turn on the left modifier for right ctrl by
+                # itself, as it shouldn't make a difference.
+                left_ctrl_modifier=True,
+                right_alt_modifier=False,
+                key='Control',
+                key_code=17,
+                is_left_modifier=False),
+            keystroke.parse_keystroke({
+                'metaKey': False,
+                'altKey': False,
+                'shiftKey': False,
+                'ctrlKey': True,
+                'altGraphKey': False,
+                'key': 'Control',
+                'keyCode': 17,
+                'location': 'right',
             }))
 
     def test_rejects_invalid_meta_modifier(self):
@@ -53,6 +106,7 @@ class KeystrokeTest(unittest.TestCase):
                 'altGraphKey': False,
                 'key': 'A',
                 'keyCode': 65,
+                'location': None,
             })
 
     def test_rejects_invalid_alt_modifier(self):
@@ -65,6 +119,7 @@ class KeystrokeTest(unittest.TestCase):
                 'altGraphKey': False,
                 'key': 'A',
                 'keyCode': 65,
+                'location': None,
             })
 
     def test_rejects_invalid_shift_modifier(self):
@@ -77,6 +132,7 @@ class KeystrokeTest(unittest.TestCase):
                 'altGraphKey': False,
                 'key': 'A',
                 'keyCode': 65,
+                'location': None,
             })
 
     def test_rejects_invalid_ctrl_modifier(self):
@@ -89,6 +145,7 @@ class KeystrokeTest(unittest.TestCase):
                 'altGraphKey': False,
                 'key': 'A',
                 'keyCode': 65,
+                'location': None,
             })
 
     def test_rejects_invalid_alt_graph_modifier(self):
@@ -101,6 +158,7 @@ class KeystrokeTest(unittest.TestCase):
                 'altGraphKey': 'banana',
                 'key': 'A',
                 'keyCode': 65,
+                'location': None,
             })
 
     def test_rejects_negative_keycode_value(self):
@@ -113,6 +171,7 @@ class KeystrokeTest(unittest.TestCase):
                 'altGraphKey': False,
                 'key': 'A',
                 'keyCode': -1,
+                'location': None,
             })
 
     def test_rejects_too_high_keycode_value(self):
@@ -125,6 +184,7 @@ class KeystrokeTest(unittest.TestCase):
                 'altGraphKey': False,
                 'key': 'A',
                 'keyCode': 0xff + 1,
+                'location': None,
             })
 
     def test_rejects_string_keycode_value(self):
@@ -137,6 +197,7 @@ class KeystrokeTest(unittest.TestCase):
                 'altGraphKey': False,
                 'key': 'A',
                 'keyCode': 'banana',
+                'location': None,
             })
 
     def test_rejects_float_keycode_value(self):
@@ -149,6 +210,20 @@ class KeystrokeTest(unittest.TestCase):
                 'altGraphKey': False,
                 'key': 'A',
                 'keyCode': 1.25,
+                'location': None,
+            })
+
+    def test_rejects_invalid_location_value(self):
+        with self.assertRaises(keystroke.InvalidLocation):
+            keystroke.parse_keystroke({
+                'metaKey': False,
+                'altKey': False,
+                'shiftKey': False,
+                'ctrlKey': False,
+                'altGraphKey': False,
+                'key': 'A',
+                'keyCode': 65,
+                'location': 12345,
             })
 
     def test_rejects_missing_meta_key_value(self):
@@ -160,6 +235,7 @@ class KeystrokeTest(unittest.TestCase):
                 'altGraphKey': False,
                 'key': 'A',
                 'keyCode': 1,
+                'location': None,
             })
 
     def test_rejects_missing_alt_key_value(self):
@@ -182,6 +258,7 @@ class KeystrokeTest(unittest.TestCase):
                 'ctrlKey': False,
                 'key': 'A',
                 'keyCode': 1,
+                'location': None,
             })
 
     def test_rejects_missing_shift_key_value(self):
@@ -193,6 +270,7 @@ class KeystrokeTest(unittest.TestCase):
                 'altGraphKey': False,
                 'key': 'A',
                 'keyCode': 1,
+                'location': None,
             })
 
     def test_rejects_missing_ctrl_key_value(self):
@@ -204,6 +282,7 @@ class KeystrokeTest(unittest.TestCase):
                 'altGraphKey': False,
                 'key': 'A',
                 'keyCode': 1,
+                'location': None,
             })
 
     def test_rejects_missing_key_value(self):
@@ -215,6 +294,7 @@ class KeystrokeTest(unittest.TestCase):
                 'ctrlKey': False,
                 'altGraphKey': False,
                 'keyCode': 1,
+                'location': None,
             })
 
     def test_rejects_missing_key_code_value(self):
@@ -226,4 +306,17 @@ class KeystrokeTest(unittest.TestCase):
                 'ctrlKey': False,
                 'altGraphKey': False,
                 'key': 'A',
+                'location': None,
+            })
+
+    def test_rejects_missing_location_value(self):
+        with self.assertRaises(keystroke.MissingField):
+            keystroke.parse_keystroke({
+                'metaKey': False,
+                'altKey': False,
+                'shiftKey': False,
+                'ctrlKey': False,
+                'altGraphKey': False,
+                'key': 'A',
+                'keyCode': 1,
             })

--- a/app/tests/request_parsers/test_keystroke.py
+++ b/app/tests/request_parsers/test_keystroke.py
@@ -78,8 +78,9 @@ class KeystrokeTest(unittest.TestCase):
                 left_meta_modifier=False,
                 left_alt_modifier=False,
                 left_shift_modifier=False,
-                # For simplicity, we turn on the left modifier for right ctrl by
-                # itself, as it shouldn't make a difference.
+                # For simplicity, we store right Ctrl modifier in
+                # left_ctrl_modifier since there's no right version in
+                # keystroke.Keystroke.
                 left_ctrl_modifier=True,
                 right_alt_modifier=False,
                 key='Control',

--- a/app/tests/test_js_to_hid.py
+++ b/app/tests/test_js_to_hid.py
@@ -17,7 +17,8 @@ class ConvertJsToHIDTest(unittest.TestCase):
                                 left_ctrl_modifier=False,
                                 right_alt_modifier=False,
                                 key='a',
-                                key_code=65), 'qwerty')
+                                key_code=65,
+                                is_left_modifier=False), 'qwerty')
         self.assertEqual(0, modifier_bitmask)
         self.assertEqual(qwerty.KEYCODE_A, hid_keycode)
 
@@ -29,11 +30,20 @@ class ConvertJsToHIDTest(unittest.TestCase):
                                 left_ctrl_modifier=False,
                                 right_alt_modifier=False,
                                 key='A',
+<<<<<<< HEAD
                                 key_code=65), 'qwerty')
         self.assertEqual(modifiers.LEFT_SHIFT, modifier_bitmask)
         self.assertEqual(qwerty.KEYCODE_A, hid_keycode)
 
     def test_converts_keystroke_with_all_modifiers_pressed(self):
+=======
+                                key_code=65,
+                                is_left_modifier=False), 'qwerty')
+        self.assertEqual(0x02, modifier_bitmask)
+        self.assertEqual(qwerty.KEYCODE_A, hid_keycode)
+
+    def test_converts_keystroke_with_all_modifier_bitmask_pressed(self):
+>>>>>>> Add support for right modifier keys
         modifier_bitmask, hid_keycode = convert(
             keystroke.Keystroke(left_meta_modifier=True,
                                 left_alt_modifier=True,
@@ -41,10 +51,16 @@ class ConvertJsToHIDTest(unittest.TestCase):
                                 left_ctrl_modifier=True,
                                 right_alt_modifier=True,
                                 key='A',
+<<<<<<< HEAD
                                 key_code=65), 'qwerty')
         self.assertEqual(
             modifiers.LEFT_META | modifiers.LEFT_ALT | modifiers.LEFT_SHIFT |
             modifiers.LEFT_CTRL | modifiers.RIGHT_ALT, modifier_bitmask)
+=======
+                                key_code=65,
+                                is_left_modifier=False), 'qwerty')
+        self.assertEqual(0x4f, modifier_bitmask)
+>>>>>>> Add support for right modifier keys
         self.assertEqual(qwerty.KEYCODE_A, hid_keycode)
 
     def test_converts_left_ctrl_keystroke(self):
@@ -55,9 +71,23 @@ class ConvertJsToHIDTest(unittest.TestCase):
                                 left_ctrl_modifier=True,
                                 right_alt_modifier=False,
                                 key='Control',
-                                key_code=17), 'qwerty')
+                                key_code=17,
+                                is_left_modifier=True), 'qwerty')
         self.assertEqual(modifiers.LEFT_CTRL, modifier_bitmask)
         self.assertEqual(qwerty.KEYCODE_LEFT_CTRL, hid_keycode)
+
+    def test_converts_right_ctrl_keystroke(self):
+        modifier_bitmask, hid_keycode = convert(
+            keystroke.Keystroke(left_meta_modifier=False,
+                                left_alt_modifier=False,
+                                left_shift_modifier=False,
+                                left_ctrl_modifier=True,
+                                right_alt_modifier=False,
+                                key='Control',
+                                key_code=17,
+                                is_left_modifier=False), 'qwerty')
+        self.assertEqual(modifiers.LEFT_CTRL, modifier_bitmask)
+        self.assertEqual(qwerty.KEYCODE_RIGHT_CTRL, hid_keycode)
 
     def test_converts_simple_azerty_keystroke(self):
         modifier_bitmask, hid_keycode = convert(
@@ -67,6 +97,7 @@ class ConvertJsToHIDTest(unittest.TestCase):
                                 left_ctrl_modifier=False,
                                 right_alt_modifier=False,
                                 key='a',
-                                key_code=65), 'azerty')
+                                key_code=65,
+                                is_left_modifier=False), 'azerty')
         self.assertEqual(0, modifier_bitmask)
         self.assertEqual(azerty.KEYCODE_A, hid_keycode)

--- a/app/tests/test_js_to_hid.py
+++ b/app/tests/test_js_to_hid.py
@@ -31,7 +31,7 @@ class ConvertJsToHIDTest(unittest.TestCase):
                                 right_alt_modifier=False,
                                 key='A',
                                 key_code=65,
-                                is_right_modifier=True), 'qwerty')
+                                is_right_modifier=False), 'qwerty')
         self.assertEqual(modifiers.LEFT_SHIFT, modifier_bitmask)
         self.assertEqual(qwerty.KEYCODE_A, hid_keycode)
 
@@ -73,7 +73,7 @@ class ConvertJsToHIDTest(unittest.TestCase):
                                 key='Control',
                                 key_code=17,
                                 is_right_modifier=True), 'qwerty')
-        self.assertEqual(modifiers.LEFT_CTRL, modifier_bitmask)
+        self.assertEqual(modifiers.RIGHT_CTRL, modifier_bitmask)
         self.assertEqual(qwerty.KEYCODE_RIGHT_CTRL, hid_keycode)
 
     def test_converts_simple_azerty_keystroke(self):

--- a/app/tests/test_js_to_hid.py
+++ b/app/tests/test_js_to_hid.py
@@ -18,7 +18,7 @@ class ConvertJsToHIDTest(unittest.TestCase):
                                 right_alt_modifier=False,
                                 key='a',
                                 key_code=65,
-                                is_left_modifier=False), 'qwerty')
+                                is_right_modifier=False), 'qwerty')
         self.assertEqual(0, modifier_bitmask)
         self.assertEqual(qwerty.KEYCODE_A, hid_keycode)
 
@@ -31,7 +31,7 @@ class ConvertJsToHIDTest(unittest.TestCase):
                                 right_alt_modifier=False,
                                 key='A',
                                 key_code=65,
-                                is_left_modifier=True), 'qwerty')
+                                is_right_modifier=True), 'qwerty')
         self.assertEqual(modifiers.LEFT_SHIFT, modifier_bitmask)
         self.assertEqual(qwerty.KEYCODE_A, hid_keycode)
 
@@ -44,7 +44,7 @@ class ConvertJsToHIDTest(unittest.TestCase):
                                 right_alt_modifier=True,
                                 key='A',
                                 key_code=65,
-                                is_left_modifier=False), 'qwerty')
+                                is_right_modifier=False), 'qwerty')
         self.assertEqual(
             modifiers.LEFT_META | modifiers.LEFT_ALT | modifiers.LEFT_SHIFT |
             modifiers.LEFT_CTRL | modifiers.RIGHT_ALT, modifier_bitmask)
@@ -59,7 +59,7 @@ class ConvertJsToHIDTest(unittest.TestCase):
                                 right_alt_modifier=False,
                                 key='Control',
                                 key_code=17,
-                                is_left_modifier=True), 'qwerty')
+                                is_right_modifier=False), 'qwerty')
         self.assertEqual(modifiers.LEFT_CTRL, modifier_bitmask)
         self.assertEqual(qwerty.KEYCODE_LEFT_CTRL, hid_keycode)
 
@@ -72,7 +72,7 @@ class ConvertJsToHIDTest(unittest.TestCase):
                                 right_alt_modifier=False,
                                 key='Control',
                                 key_code=17,
-                                is_left_modifier=False), 'qwerty')
+                                is_right_modifier=True), 'qwerty')
         self.assertEqual(modifiers.LEFT_CTRL, modifier_bitmask)
         self.assertEqual(qwerty.KEYCODE_RIGHT_CTRL, hid_keycode)
 
@@ -85,6 +85,6 @@ class ConvertJsToHIDTest(unittest.TestCase):
                                 right_alt_modifier=False,
                                 key='a',
                                 key_code=65,
-                                is_left_modifier=False), 'azerty')
+                                is_right_modifier=False), 'azerty')
         self.assertEqual(0, modifier_bitmask)
         self.assertEqual(azerty.KEYCODE_A, hid_keycode)

--- a/app/tests/test_js_to_hid.py
+++ b/app/tests/test_js_to_hid.py
@@ -30,20 +30,12 @@ class ConvertJsToHIDTest(unittest.TestCase):
                                 left_ctrl_modifier=False,
                                 right_alt_modifier=False,
                                 key='A',
-<<<<<<< HEAD
-                                key_code=65), 'qwerty')
+                                key_code=65,
+                                is_left_modifier=True), 'qwerty')
         self.assertEqual(modifiers.LEFT_SHIFT, modifier_bitmask)
         self.assertEqual(qwerty.KEYCODE_A, hid_keycode)
 
     def test_converts_keystroke_with_all_modifiers_pressed(self):
-=======
-                                key_code=65,
-                                is_left_modifier=False), 'qwerty')
-        self.assertEqual(0x02, modifier_bitmask)
-        self.assertEqual(qwerty.KEYCODE_A, hid_keycode)
-
-    def test_converts_keystroke_with_all_modifier_bitmask_pressed(self):
->>>>>>> Add support for right modifier keys
         modifier_bitmask, hid_keycode = convert(
             keystroke.Keystroke(left_meta_modifier=True,
                                 left_alt_modifier=True,
@@ -51,16 +43,11 @@ class ConvertJsToHIDTest(unittest.TestCase):
                                 left_ctrl_modifier=True,
                                 right_alt_modifier=True,
                                 key='A',
-<<<<<<< HEAD
-                                key_code=65), 'qwerty')
+                                key_code=65,
+                                is_left_modifier=False), 'qwerty')
         self.assertEqual(
             modifiers.LEFT_META | modifiers.LEFT_ALT | modifiers.LEFT_SHIFT |
             modifiers.LEFT_CTRL | modifiers.RIGHT_ALT, modifier_bitmask)
-=======
-                                key_code=65,
-                                is_left_modifier=False), 'qwerty')
-        self.assertEqual(0x4f, modifier_bitmask)
->>>>>>> Add support for right modifier keys
         self.assertEqual(qwerty.KEYCODE_A, hid_keycode)
 
     def test_converts_left_ctrl_keystroke(self):


### PR DESCRIPTION
Initially, TinyPilot assumed that all modifier key presses were left keys, but there are some devices where left vs. right modifier keys make a difference.