### PR TITLE
Revert the meta viewport tag to one that's more standard

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,10 +12,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
-    />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="csrf-token" content="{{ csrf_token() }}" />
   </head>
   <body>


### PR DESCRIPTION
Setting user-scalable=no has the potential to create accessibility issues for users who need to zoom. Reverting this tag back to the standard, common value.