### PR TITLE
Fix bad reference to normalizeWheelDelta

### DIFF
--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -82,6 +82,15 @@
       .ownerDocument;
     const template = doc.querySelector("#remote-screen-template");
 
+    // Different browsers produce wildly different values for wheel scroll
+    // delta, so just reduce it to -1, 0, or 1.
+    function normalizeWheelDelta(delta) {
+      if (!delta) {
+        return 0;
+      }
+      return Math.sign(delta);
+    }
+
     customElements.define(
       "remote-screen",
       class extends HTMLElement {
@@ -275,15 +284,6 @@
           );
         }
 
-        // Different browsers produce wildly different values for wheel scroll
-        // delta, so just reduce it to -1, 0, or 1.
-        normalizeWheelDelta(delta) {
-          if (!delta) {
-            return 0;
-          }
-          return Math.sign(delta);
-        }
-
         sendMouseEvent(evt) {
           const boundingRect = evt.target.getBoundingClientRect();
           const cursorX = Math.max(0, evt.clientX - boundingRect.left);
@@ -293,8 +293,8 @@
           const relativeX = Math.min(1.0, Math.max(0.0, cursorX / width));
           const relativeY = Math.min(1.0, Math.max(0.0, cursorY / height));
           // Negate y-delta so that negative number means scroll down.
-          const verticalWheelDelta = this.normalizeWheelDelta(evt.deltaY) * -1;
-          const horizontalWheelDelta = this.normalizeWheelDelta(evt.deltaX);
+          const verticalWheelDelta = normalizeWheelDelta(evt.deltaY) * -1;
+          const horizontalWheelDelta = normalizeWheelDelta(evt.deltaX);
           this.dispatchEvent(
             new CustomEvent("mouse-event", {
               detail: {


### PR DESCRIPTION
In some cases, the call fails when the 'this' reference is not set, so move the function out of the class context so that it always is defined.