### PR TITLE
Remove workaround for legacy KVM Pi Nginx config

### DIFF
--- a/quick-install
+++ b/quick-install
@@ -6,13 +6,6 @@ set -x
 # Exit on first error.
 set -e
 
-# Remove the legacy nginx config, as it will conflict with tinypilot.conf if
-# both are present.
-if [ -f /etc/nginx/sites-enabled/KVMPi.conf ]
-then
-  sudo rm /etc/nginx/sites-enabled/KVMPi.conf
-fi
-
 if [ -z "$TINYPILOT_INSTALL_VARS" ]
 then
   TINYPILOT_INSTALL_VARS=""


### PR DESCRIPTION
This is a workaround from a very early version of TinyPilot when it was known as KVM Pi. At this point, it's unlikely that any users are running a version of TinyPilot that require this workaround, so we're removing it.