### PR TITLE
Set install options in the quick-install script

### DIFF
--- a/quick-install
+++ b/quick-install
@@ -3,19 +3,50 @@
 # Echo commands to stdout.
 set -x
 
-# Exit on first error.
-set -e
-
 if [ -z "$TINYPILOT_INSTALL_VARS" ]
 then
   TINYPILOT_INSTALL_VARS=""
   echo "Using default install vars"
 else
-  echo "Install vars: $TINYPILOT_INSTALL_VARS"
+  echo "User-specified install vars: $TINYPILOT_INSTALL_VARS"
+fi
+
+# Check if this system uses the TC358743 HDMI to CSI capture bridge.
+USE_TC358743_DEFAULTS=''
+if [ -f /home/ustreamer/config.yml ] && grep --silent 'capture_device: "tc358743"' /home/ustreamer/config.yml; then
+  USE_TC358743_DEFAULTS='y'
+fi
+if [[ "$TINYPILOT_INSTALL_VARS" =~ 'ustreamer_capture_device=tc358743' ]]; then
+  USE_TC358743_DEFAULTS='y'
+fi
+
+# If this system does not use a TC358743 capture chip, set defaults for any
+# unset install variables.
+if [ -z "$USE_TC358743_DEFAULTS" ]; then
+  if [[ ! "$TINYPILOT_INSTALL_VARS" =~ 'ustreamer_encoder=' ]]; then
+    TINYPILOT_INSTALL_VARS+=" ustreamer_encoder=hw"
+  fi
+  if [[ ! "$TINYPILOT_INSTALL_VARS" =~ 'ustreamer_format=' ]]; then
+    TINYPILOT_INSTALL_VARS+=" ustreamer_format=jpeg"
+  fi
+  if [[ ! "$TINYPILOT_INSTALL_VARS" =~ 'ustreamer_resolution=' ]]; then
+    TINYPILOT_INSTALL_VARS+=" ustreamer_resolution=1920x1080"
+  fi
+  if [[ ! "$TINYPILOT_INSTALL_VARS" =~ 'ustreamer_persistent=' ]]; then
+    TINYPILOT_INSTALL_VARS+=" ustreamer_persistent=true"
+  fi
+  if [[ ! "$TINYPILOT_INSTALL_VARS" =~ 'ustreamer_desired_fps=' ]]; then
+    TINYPILOT_INSTALL_VARS+=" ustreamer_desired_fps=30"
+  fi
 fi
 
 # Treat undefined environment variables as errors.
 set -u
+
+# Exit on first error.
+set -e
+
+echo "Final install vars: $TINYPILOT_INSTALL_VARS"
 
 pushd $(mktemp -d)
 sudo apt-get update


### PR DESCRIPTION
Previously, we relied on ansible-role-tinypilot to set default settings for uStreamer, but this isn't very flexible. Instead, we're moving the defaults here so that ansible-role-tinypilot does not set any of its own uStreamer options and instead leaves those decisions to higher-level clients, like this installer.