### PR TITLE
Display keypress for meta key

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -144,10 +144,7 @@ function processKeystroke(keystroke) {
   if (keystroke.keyCode === 229) {
     resolve({});
   }
-  let keyCard = undefined;
-  if (!keystroke.metaKey) {
-    keyCard = addKeyCard(keystroke.key);
-  }
+  let keyCard = addKeyCard(keystroke.key);
   sendKeystroke(socket, keystroke)
     .then(() => {
       keyCard.classList.add("processed-key-card");


### PR DESCRIPTION
Previously we were hiding it from the keystroke history, but we may as well show it. It's not worth adding special rules for meta.