### PR TITLE
Adjust property names in on screen keyboard

### DIFF
--- a/app/templates/custom-elements/key.html
+++ b/app/templates/custom-elements/key.html
@@ -95,7 +95,7 @@
 
             // Don't send event if click removed "pressed" state
             // on a modifier key.
-            if (!this.modifier || this.pressed) {
+            if (!this.isModifier || this.isPressed) {
               const clickedKey = this;
               this.dispatchEvent(
                 new CustomEvent("keyclick", {
@@ -133,7 +133,7 @@
           return keyLabel.replace(" ", "");
         }
 
-        get modifier() {
+        get isModifier() {
           return this.getAttribute("modifier") === "true";
         }
 
@@ -147,19 +147,19 @@
           }
         }
 
-        get pressed() {
+        get isPressed() {
           return this.getAttribute("pressed") === "true";
         }
 
-        set pressed(newValue) {
+        set isPressed(newValue) {
           // Only modifier keys can be "pressed".
-          if (this.modifier) {
+          if (this.isModifier) {
             this.setAttribute("pressed", newValue);
           }
         }
 
         togglePressedState() {
-          this.pressed = !this.pressed;
+          this.isPressed = !this.isPressed;
         }
       }
     );

--- a/app/templates/custom-elements/on-screen-keyboard.html
+++ b/app/templates/custom-elements/on-screen-keyboard.html
@@ -334,7 +334,7 @@
 
           this.emitKeyDownEvent(keyValue, key.location, key.code);
 
-          if (!key.modifier) {
+          if (!key.isModifier) {
             this.emitKeyUpEvent(keyValue, key.location, key.code);
 
             // Remove pressed state from all modifier keys if non-modifier key
@@ -414,7 +414,7 @@
           this.shadowRoot
             .querySelectorAll("[modifier=true][pressed=true]")
             .forEach((key) => {
-              key.pressed = false;
+              key.isPressed = false;
               this.emitKeyUpEvent(key.value, key.location, key.code);
             });
         }


### PR DESCRIPTION
Adds is- prefix to boolean properties to eliminate ambiguity about what type of value they store.