### PR TITLE
Fix keycodes for meta keys on on-screen keyboard

### DIFF
--- a/app/templates/custom-elements/on-screen-keyboard.html
+++ b/app/templates/custom-elements/on-screen-keyboard.html
@@ -220,7 +220,7 @@
           >Control</keyboard-key
         >
         <keyboard-key
-          code="102"
+          code="91"
           modifier="true"
           location="left"
           class="meta-modifier key-extend-half accented"
@@ -242,7 +242,7 @@
           >Alt</keyboard-key
         >
         <keyboard-key
-          code="102"
+          code="92"
           modifier="true"
           location="right"
           class="meta-modifier key-extend-half accented"


### PR DESCRIPTION
The Meta keys were incorrectly assigned to 102, which is the numpad 6 button.