### PR TITLE
Communicate keyclick details explicitly

### DIFF
--- a/app/templates/custom-elements/key.html
+++ b/app/templates/custom-elements/key.html
@@ -100,10 +100,14 @@
             // Don't send event if click removed "pressed" state
             // on a modifier key.
             if (!this.isModifier || this.isPressed) {
-              const clickedKey = this;
               this.dispatchEvent(
                 new CustomEvent("keyclick", {
-                  detail: { key: clickedKey },
+                  detail: {
+                    key: this.value,
+                    location: this.location,
+                    code: this.code,
+                    isModifier: this.isModifier,
+                  },
                   bubbles: true,
                   composed: true,
                 })

--- a/app/templates/custom-elements/on-screen-keyboard.html
+++ b/app/templates/custom-elements/on-screen-keyboard.html
@@ -323,13 +323,16 @@
           this.shadowRoot.appendChild(template.content.cloneNode(true));
 
           this.addEventListener("keyclick", (evt) => {
-            this.onKeyClick(evt.detail.key);
+            this.onKeyClick(
+              evt.detail.key,
+              evt.detail.location,
+              evt.detail.code,
+              evt.detail.isModifier
+            );
           });
         }
 
-        onKeyClick(key) {
-          let keyValue = key.value;
-
+        onKeyClick(key, location, code, isModifier) {
           if (
             this.isShiftKeyPressed &&
             !this.isMetaKeyPressed &&
@@ -337,13 +340,13 @@
             !this.isCtrlKeyPressed &&
             !this.isSysrqKeyPressed
           ) {
-            keyValue = this.getShiftedKeyValue(keyValue);
+            key = this.getShiftedKeyValue(key);
           }
 
-          this.emitKeyDownEvent(keyValue, key.location, key.code);
+          this.emitKeyDownEvent(key, location, code);
 
-          if (!key.isModifier) {
-            this.emitKeyUpEvent(keyValue, key.location, key.code);
+          if (!isModifier) {
+            this.emitKeyUpEvent(key, location, code);
 
             // Remove pressed state from all modifier keys if non-modifier key
             // was pressed.


### PR DESCRIPTION
To avoid passing more data than necessary in the key click event, pass the explicit values we care about.