### PR TITLE
Support altGraph key on on-screen keyboard

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -175,7 +175,9 @@ function onKeyDown(evt) {
     altKey: evt.altKey || onScreenKeyboard.isAltKeyPressed,
     shiftKey: evt.shiftKey || onScreenKeyboard.isShiftKeyPressed,
     ctrlKey: evt.ctrlKey || onScreenKeyboard.isCtrlKeyPressed,
-    altGraphKey: isAltGraphPressed(browserLanguage(), evt.keyCode, evt.key),
+    altGraphKey:
+      isAltGraphPressed(browserLanguage(), evt.keyCode, evt.key) ||
+      onScreenKeyboard.isRightAltKeyPressed,
     sysrqKey: onScreenKeyboard.isSysrqKeyPressed,
     key: evt.key,
     keyCode: evt.keyCode,

--- a/app/templates/custom-elements/on-screen-keyboard.html
+++ b/app/templates/custom-elements/on-screen-keyboard.html
@@ -369,6 +369,10 @@
           return this.isModifierKeyPressed("alt");
         }
 
+        get isRightAltKeyPressed() {
+          return this.isModifierKeyPressed("alt", "right");
+        }
+
         get isShiftKeyPressed() {
           return this.isModifierKeyPressed("shift");
         }
@@ -381,7 +385,12 @@
           return this.isModifierKeyPressed("sysrq");
         }
 
-        isModifierKeyPressed(modifier) {
+        isModifierKeyPressed(modifier, location) {
+          let locationSpecifier = "";
+          if (location) {
+            locationSpecifier = ` location="${location}"`;
+          }
+          let selector = `.${modifier}-modifier[pressed=true${locationSpecifier}]`;
           return (
             this.shadowRoot.querySelectorAll(
               `.${modifier}-modifier[pressed=true]`


### PR DESCRIPTION
Previously, the on-screen keyboard never distinguished between left or right alt keys being pressed, but on certain keyboard layouts, the right alt is treated as AltGraph and has special meaning.

This change causes pressing the right alt key on the on-screen keyboard to set altGraphKey: true in the socket.io message to the backend, so that the backend translates it properly as a right alt modifier.

The behavior is not perfect in that it will treat holding the right alt key the same as holding both alt keys at once, but hopefully this moves us closer to a complete solution.

Fixes #350