### PR TITLE
Ensure socket API communicates success robustly

### DIFF
--- a/app/socket_api.py
+++ b/app/socket_api.py
@@ -36,7 +36,7 @@ def socket_keystroke(message):
         keystroke = keystroke_request.parse_keystroke(message)
     except keystroke_request.Error as e:
         logger.error('Failed to parse keystroke request: %s', e)
-        return
+        return {'success': False}
     hid_keycode = None
     try:
         control_keys, hid_keycode = js_to_hid.convert(keystroke,

--- a/app/static/js/keystrokes.js
+++ b/app/static/js/keystrokes.js
@@ -4,7 +4,7 @@
 export function sendKeystroke(socket, keystroke) {
   return new Promise((resolve, reject) => {
     socket.emit("keystroke", keystroke, (result) => {
-      if (result.success) {
+      if ("success" in result && result.success) {
         resolve({});
       } else {
         reject(new Error("Failed to forward keystroke"));


### PR DESCRIPTION
Fix a code path where the backend wasn't setting the success property of the response.
Adjust the JS code so that it doesn't crash when the success property is missing.