### PR TITLE
Separate left alt from right alt on on-screen keyboard

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -170,7 +170,7 @@ function onKeyDown(evt) {
 
   processKeystroke({
     metaKey: evt.metaKey || onScreenKeyboard.isMetaKeyPressed,
-    altKey: evt.altKey || onScreenKeyboard.isAltKeyPressed,
+    altKey: evt.altKey || onScreenKeyboard.isLeftAltKeyPressed,
     shiftKey: evt.shiftKey || onScreenKeyboard.isShiftKeyPressed,
     ctrlKey: evt.ctrlKey || onScreenKeyboard.isCtrlKeyPressed,
     altGraphKey:

--- a/app/templates/custom-elements/on-screen-keyboard.html
+++ b/app/templates/custom-elements/on-screen-keyboard.html
@@ -326,7 +326,8 @@
           if (
             this.isShiftKeyPressed &&
             !this.isMetaKeyPressed &&
-            !this.isAltKeyPressed &&
+            !this.isLeftAltKeyPressed &&
+            !this.isRightAltKeyPressed &&
             !this.isCtrlKeyPressed &&
             !this.isSysrqKeyPressed
           ) {
@@ -348,8 +349,12 @@
           return this.isModifierKeyPressed("meta");
         }
 
-        get isAltKeyPressed() {
-          return this.isModifierKeyPressed("alt");
+        get isLeftAltKeyPressed() {
+          return (
+            this.shadowRoot.querySelectorAll(
+              '.alt-modifier[code="AltLeft"][pressed=true]'
+            ).length > 0
+          );
         }
 
         get isRightAltKeyPressed() {
@@ -388,7 +393,7 @@
               key: key,
               code: code,
               metaKey: this.isMetaKeyPressed,
-              altKey: this.isAltKeyPressed,
+              altKey: this.isLeftAltKeyPressed,
               shiftKey: this.isShiftKeyPressed,
               ctrlKey: this.isCtrlKeyPressed,
             })
@@ -403,7 +408,7 @@
               key: key,
               code: code,
               metaKey: this.isMetaKeyPressed,
-              altKey: this.isAltKeyPressed,
+              altKey: this.isLeftAltKeyPressed,
               shiftKey: this.isShiftKeyPressed,
               ctrlKey: this.isCtrlKeyPressed,
             })


### PR DESCRIPTION
We eventually need to move to a system where we track orientation of all modifier keys, but as a stopgap for now, keep the left alt and right alt modifiers separate on the on-screen keyboard.