### PR TITLE
Upgrade Flask-SocketIO to 4.3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 eventlet==0.25.2
 Flask==1.1.1
-Flask-SocketIO==4.3.0
+Flask-SocketIO==4.3.2
 Flask-WTF==0.14.3


### PR DESCRIPTION
4.3.0 had a bug where it would upgrade to any version of python-socketio>=4.3.0. The issue is that python-socketio 5.x is incompatible with clients using JavaScript Socket.IO versions 1.x and 2.x, so it would upgrade to the latest version of python-socketio and break existing clients. This was fixed in:

https://github.com/miguelgrinberg/Flask-SocketIO/commit/59740d3eb50395f44cfb786b85215b4ec9b795e9#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7

See also: https://github.com/miguelgrinberg/python-socketio/issues/578
See also: https://github.com/mtlynch/tinypilot/issues/368#issuecomment-742316061