### PR TITLE
Use permanent installer directory

### DIFF
--- a/quick-install
+++ b/quick-install
@@ -51,9 +51,13 @@ set -e
 
 echo "Final install vars: $TINYPILOT_INSTALL_VARS"
 
-pushd $(mktemp -d)
 sudo apt-get update
 sudo apt-get install -y libffi-dev libssl-dev python3-dev python3-venv
+
+INSTALLER_DIR="/opt/tinypilot-updater"
+sudo mkdir -p "$INSTALLER_DIR"
+pushd "$INSTALLER_DIR"
+
 python3 -m venv venv
 . venv/bin/activate
 # Ansible depends on wheel.

--- a/quick-install
+++ b/quick-install
@@ -56,6 +56,7 @@ sudo apt-get install -y libffi-dev libssl-dev python3-dev python3-venv
 
 INSTALLER_DIR="/opt/tinypilot-updater"
 sudo mkdir -p "$INSTALLER_DIR"
+sudo chown "$(whoami):$(whoami)" "$INSTALLER_DIR"
 pushd "$INSTALLER_DIR"
 
 python3 -m venv venv


### PR DESCRIPTION
Upgrades are slow now partially because we throw away the installer's virtualenv and recreate it from scratch. If we keep a permanent updater directory alongside the actual app, we can upgrade faster.