### PR TITLE
Install ansible role requirements through requirements.yml

### DIFF
--- a/quick-install
+++ b/quick-install
@@ -68,7 +68,8 @@ echo "[defaults]
 roles_path = $PWD
 interpreter_python = /usr/bin/python3
 " > ansible.cfg
-ansible-galaxy install mtlynch.tinypilot
+git clone https://github.com/mtlynch/ansible-role-tinypilot.git mtlynch.tinypilot
+ansible-galaxy install --role-file mtlynch.tinypilot/requirements.yml
 echo "- hosts: localhost
   connection: local
   become: true


### PR DESCRIPTION
We're transitioning away from installing roles implicitly through meta/main.yml, as it doesn't allow us to apply any logic before the install of dependent roles. If we install via the requirements.yml, we can choose when in the role we want to pull in the parent roles and add more sophisticated logic to them instead of installing them right off the bat with the default variable assignments.