### PR TITLE
Install git during quick-install script

### DIFF
--- a/quick-install
+++ b/quick-install
@@ -52,7 +52,12 @@ set -e
 echo "Final install vars: $TINYPILOT_INSTALL_VARS"
 
 sudo apt-get update
-sudo apt-get install -y libffi-dev libssl-dev python3-dev python3-venv
+sudo apt-get install -y \
+  git \
+  libffi-dev \
+  libssl-dev \
+  python3-dev \
+  python3-venv
 
 INSTALLER_DIR="/opt/tinypilot-updater"
 sudo mkdir -p "$INSTALLER_DIR"


### PR DESCRIPTION
quick-install depends directly on git as of 7c4aecb, so the installer should make sure that git is installed already.

Fixes #387