### PR TITLE
Recursively chown installer directory

### DIFF
--- a/quick-install
+++ b/quick-install
@@ -61,7 +61,7 @@ sudo apt-get install -y \
 
 INSTALLER_DIR="/opt/tinypilot-updater"
 sudo mkdir -p "$INSTALLER_DIR"
-sudo chown "$(whoami):$(whoami)" "$INSTALLER_DIR"
+sudo chown "$(whoami):$(whoami)" --recursive "$INSTALLER_DIR"
 pushd "$INSTALLER_DIR"
 
 python3 -m venv venv


### PR DESCRIPTION
Otherwise, only the outer installer directory is owned by the current user, while the contents may not be.