### PR TITLE
Create new "update" API endpoints

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -1,6 +1,8 @@
 import flask
 
+import git
 import local_system
+import update
 
 api_blueprint = flask.Blueprint('api', __name__, url_prefix='/api')
 
@@ -20,6 +22,97 @@ def restart_post():
         local_system.restart()
         return _json_success()
     except local_system.Error as e:
+        return _json_error(str(e)), 500
+
+
+@api_blueprint.route('/update', methods=['POST'])
+def update_post():
+    """Updates TinyPilot to the latest version available.
+
+    This is a slow endpoint, as it is expected to take 2~4 minutes to
+    complete.
+
+    Returns:
+        A JSON string with two keys: success and error.
+
+        success: true if successful.
+        error: null if successful, str otherwise.
+
+        Example of success:
+        {
+            'success': true,
+            'error': null,
+        }
+        Example of error:
+        {
+            'success': false,
+            'error': 'sudo: /opt/tinypilot-privileged/update: command not found'
+        }
+    """
+    try:
+        update.update()
+    except update.Error as e:
+        return _json_error(str(e)), 500
+    return _json_success()
+
+
+@api_blueprint.route('/version', methods=['GET'])
+def version_get():
+    """Retrieves the current installed version of TinyPilot.
+
+    Returns:
+        A JSON string with three keys when successful and two otherwise:
+        success, error and version (if successful).
+
+        success: true if successful.
+        error: null if successful, str otherwise.
+        version: str.
+
+        Example of success:
+        {
+            'success': true,
+            'error': null,
+            'version': 'bf07bfe72941457cf068ca0a44c6b0d62dd9ef05',
+        }
+        Example of error:
+        {
+            'success': false,
+            'error': 'git rev-parse HEAD failed.',
+        }
+    """
+    try:
+        return _json_success({"version": git.local_head_commit_id()})
+    except git.Error as e:
+        return _json_error(str(e)), 500
+
+
+@api_blueprint.route('/latestRelease', methods=['GET'])
+def latest_release_get():
+    """Retrieves the latest version of TinyPilot.
+
+    Returns:
+        A JSON string with three keys when successful and two otherwise:
+        success, error and version (if successful).
+
+        success: true if successful.
+        error: null if successful, str otherwise.
+        version: str.
+
+        Example of success:
+        {
+            'success': true,
+            'error': null,
+            'version': 'bf07bfe72941457cf068ca0a44c6b0d62dd9ef05',
+        }
+        Example of error:
+        {
+            'success': false,
+            'error': 'git rev-parse origin/master failed.',
+        }
+    """
+    try:
+        return _json_success({"version": git.remote_head_commit_id()})
+    except git.Error as e:
         return _json_error(str(e)), 500
 
 

--- a/app/git.py
+++ b/app/git.py
@@ -1,0 +1,54 @@
+import logging
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+
+class Error(Exception):
+    pass
+
+
+def local_head_commit_id():
+    """Gets the commit ID from the HEAD of the local git repository.
+
+    Returns:
+        A str containing a git commit ID from the local HEAD.
+        Example: 'bf07bfe72941457cf068ca0a44c6b0d62dd9ef05'
+
+    Raises:
+        Error: The git command failed.
+    """
+    logger.info('Getting local HEAD commit ID')
+    return _run(['git', 'rev-parse', 'HEAD']).stdout.strip()
+
+
+def remote_head_commit_id():
+    """Gets the commit ID from the HEAD of the remote git repository.
+
+    It needs to fetch git updates before retrieving the remote commit ID. It
+    might cause a delay but it should be very minimal.
+
+    Returns:
+        A str containing a git commit ID from the origin/master HEAD.
+        Example: 'bf07bfe72941457cf068ca0a44c6b0d62dd9ef05'
+
+    Raises:
+        Error: The git command failed.
+    """
+    logger.info('Getting remote HEAD commit ID')
+    _fetch()
+    return _run(['git', 'rev-parse', 'origin/master']).stdout.strip()
+
+
+def _fetch():
+    logger.info('Fetching changes')
+    return _run(['git', 'fetch'])
+
+
+def _run(cmd):
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    try:
+        result.check_returncode()
+    except subprocess.CalledProcessError:
+        raise Error(result.stderr.strip())
+    return result

--- a/app/update.py
+++ b/app/update.py
@@ -1,0 +1,30 @@
+import logging
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+
+class Error(Exception):
+    pass
+
+
+def update():
+    """Executes the TinyPilot update script.
+
+    The script takes 2~4 minutes to complete.
+
+    Returns:
+        True if successful.
+
+    Raises:
+        Error: The update script failed.
+    """
+    logger.info('Updating TinyPilot')
+    result = subprocess.run(['sudo', '/opt/tinypilot-privileged/update'],
+                            capture_output=True,
+                            text=True)
+    try:
+        result.check_returncode()
+    except subprocess.CalledProcessError:
+        raise Error(result.stderr.strip())
+    return True

--- a/quick-install
+++ b/quick-install
@@ -80,9 +80,7 @@ if [ -d "$TINYPILOT_ROLE_NAME" ]; then
   git pull origin master
   popd
 else
-  # TODO: move back to mtlynch
-  # TINYPILOT_ROLE_REPO="https://github.com/mtlynch/ansible-role-tinypilot.git"
-  TINYPILOT_ROLE_REPO="https://github.com/tretinha/ansible-role-tinypilot.git"
+  TINYPILOT_ROLE_REPO="https://github.com/mtlynch/ansible-role-tinypilot.git"
   git clone "$TINYPILOT_ROLE_REPO" "$TINYPILOT_ROLE_NAME"
 fi
 

--- a/quick-install
+++ b/quick-install
@@ -80,7 +80,9 @@ if [ -d "$TINYPILOT_ROLE_NAME" ]; then
   git pull origin master
   popd
 else
-  TINYPILOT_ROLE_REPO="https://github.com/mtlynch/ansible-role-tinypilot.git"
+  # TODO: move back to mtlynch
+  # TINYPILOT_ROLE_REPO="https://github.com/mtlynch/ansible-role-tinypilot.git"
+  TINYPILOT_ROLE_REPO="https://github.com/tretinha/ansible-role-tinypilot.git"
   git clone "$TINYPILOT_ROLE_REPO" "$TINYPILOT_ROLE_NAME"
 fi
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -1,16 +1,8 @@
 #!/usr/bin/env bash
 
-# Echo commands to stdout.
-set -x
+# avoid closing the SSH connection when returning -1
+set +e
 
-# Treat undefined environment variables as errors.
-set -u
+echo "This script has moved to /opt/tinypilot-privileged/update"
 
-# Exit on first error.
-set -e
-
-curl \
-  --silent \
-  --show-error \
-  https://raw.githubusercontent.com/mtlynch/tinypilot/master/quick-install | \
-    bash -
+return -1


### PR DESCRIPTION
The goal is to create three new endpoints that will later be used to update TinyPilot through the web UI:

* /version
* /latestRelease
* /update

This also removes the `scripts/upgrade` file from this repository (it currently resides in https://github.com/mtlynch/ansible-role-tinypilot).

It doesn't _actually_ remove the file but rather point to the user that the script location has changed.

This addresses the backend part of  #91.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mtlynch/tinypilot/407)
<!-- Reviewable:end -->
