### PR TITLE
Add sudo to the update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ TinyPilot accepts various options through environment variables:
 To update to the latest version of TinyPilot, run the update script:
 
 ```bash
-/opt/tinypilot-privileged/update && sudo reboot
+sudo /opt/tinypilot-privileged/update && sudo reboot
 ```
 
 ## Diagnostics


### PR DESCRIPTION
Non-root users can't execute the update script, so they need to call sudo first.