### PR TITLE
Require user set an environment variable to downgrade from Pro

### DIFF
--- a/quick-install
+++ b/quick-install
@@ -70,18 +70,24 @@ if [ -f "$TINYPILOT_README" ]; then
 fi
 
 if [ "$HAS_PRO_INSTALLED" = 1 ]; then
-  read -p "Are you sure you want to downgrade from TinyPilot Pro to the TinyPilot Community Edition? (y/n) " DOWNGRADE_ANSWER
-  case ${DOWNGRADE_ANSWER:0:1} in
-      y|Y )
-          echo "OK, downgrading..."
-      ;;
-      * )
-          echo "To update to the latest version of TinyPilot Pro:"
-          echo "  sudo /opt/tinypilot-privileged/update && \\"
-          echo "    sudo reboot"
-          exit 0
-      ;;
-  esac
+  set +u # Don't exit if FORCE_DOWNGRADE is unset.
+  if [ "$FORCE_DOWNGRADE" = 1 ]; then
+    echo "Downgrading from TinyPilot Pro to TinyPilot Community Edition"
+    set -u
+  else
+    set +x
+    printf "You are trying to downgrade from TinyPilot Pro to TinyPilot "
+    printf "Community Edition.\n\n"
+    printf "You probably want to update to the latest version of TinyPilot "
+    printf "Pro instead:\n\n"
+    printf "  sudo /opt/tinypilot-privileged/update && sudo reboot\n"
+    printf "\n"
+    printf "If you *really* want to downgrade to TinyPilot Community Edition, "
+    printf "type the following:\n\n"
+    printf "  export FORCE_DOWNGRADE=1\n\n"
+    printf "And then run your previous command again.\n"
+    exit -1
+  fi
 fi
 
 sudo apt-get update


### PR DESCRIPTION
Apparently the read -p command doesn't work when we're piping text into a bash interpreter, so this switches to an environment variable approach.