### PR TITLE
Make the upgrade script work again for backwards compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ TinyPilot accepts various options through environment variables:
 To update to the latest version of TinyPilot, run the update script:
 
 ```bash
-sudo /opt/tinypilot-privileged/update && sudo reboot
+/opt/tinypilot/scripts/upgrade && sudo reboot
 ```
 
 ## Diagnostics

--- a/quick-install
+++ b/quick-install
@@ -80,7 +80,7 @@ if [ "$HAS_PRO_INSTALLED" = 1 ]; then
     printf "Community Edition.\n\n"
     printf "You probably want to update to the latest version of TinyPilot "
     printf "Pro instead:\n\n"
-    printf "  sudo /opt/tinypilot-privileged/update && sudo reboot\n"
+    printf "  /opt/tinypilot/scripts/upgrade && sudo reboot\n"
     printf "\n"
     printf "If you *really* want to downgrade to TinyPilot Community Edition, "
     printf "type the following:\n\n"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-# avoid closing the SSH connection when returning -1
-set +e
+# The canonical way to update is through the update script below,
+# but this file is here for backwards compatibility.
 
-echo "This script has moved to /opt/tinypilot-privileged/update"
+# Without this file, we have no way of giving users an update command
+# that will work regardless of TinyPilot version.
 
-return -1
+sudo /opt/tinypilot-privileged/update


### PR DESCRIPTION
If we break it, we can no longer give users a single command to update that will work regardless of their version of TinyPilot.