### PR TITLE
Make a fake success message when shutdown returns 502

### DIFF
--- a/app/static/js/shutdown.js
+++ b/app/static/js/shutdown.js
@@ -26,7 +26,10 @@
         // A 502 usually means that nginx shutdown before it could process the
         // response. Treat this as success.
         if (response.status === 502) {
-          return Promise.resolve({});
+          return Promise.resolve({
+            success: true,
+            error: null,
+          });
         }
         if (response.status !== 200) {
           // See if the error response is JSON.


### PR DESCRIPTION
There's a bug in the handling of the fetch request because it attempts to resolve the Promise as success, but the next stage rejects it for not having the success parameter explicitly set in the response body. This updates it to add a fake success message becaues 502 almost certainly means shutting down the server worked.