### PR TITLE
Only do a 30s countdown during shutdown, not restart

### DIFF
--- a/app/templates/custom-elements/shutdown-dialog.html
+++ b/app/templates/custom-elements/shutdown-dialog.html
@@ -163,12 +163,12 @@
                 this.state = "restarting";
               } else {
                 this.state = "shutting-down";
+                // We can't tell when the system has fully shut down, but assume
+                // that it's done after 30 seconds.
+                setTimeout(() => {
+                  this.state = "shutdown-complete";
+                }, 30 * 1000);
               }
-              // We can't tell when the system has fully shut down, but assume
-              // that it's done after 30 seconds.
-              setTimeout(() => {
-                this.state = "shutdown-complete";
-              }, 30 * 1000);
             })
             .catch((error) => {
               if (restart) {


### PR DESCRIPTION
This fixes a bug in the logic flow. Previously, both restart and shutdown kicked off a 30 second timer to announce a shutdown is complete. The correct behavior is for restart to spin forever until it detects the server's websocket connection has been reestablished, and the shutdown flow should assume the server is shut down after 30 seconds.