### PR TITLE
Update check-trailing-whitespace to work on macOS

### DIFF
--- a/dev-scripts/check-trailing-whitespace
+++ b/dev-scripts/check-trailing-whitespace
@@ -9,11 +9,17 @@ set -e
 # Exit on unset variable.
 set -u
 
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    FOLLOW_SYMLINKS_RECURSIVELY_FLAG="-R -S"
+else
+    FOLLOW_SYMLINKS_RECURSIVELY_FLAG=--dereference-recursive
+fi
+
 if egrep \
   "\s$" \
   --line-number \
   --binary-files=without-match \
-  --dereference-recursive \
+  $FOLLOW_SYMLINKS_RECURSIVELY_FLAG \
   --exclude-dir={.git,venv,node_modules} \
   ./ ; then
   echo "ERROR: Found trailing whitespace";

--- a/dev-scripts/check-trailing-whitespace
+++ b/dev-scripts/check-trailing-whitespace
@@ -9,17 +9,17 @@ set -e
 # Exit on unset variable.
 set -u
 
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    FOLLOW_SYMLINKS_RECURSIVELY_FLAG="-R -S"
+if [[ "${OSTYPE}" == "darwin"* ]]; then
+  FOLLOW_SYMLINKS_RECURSIVELY_FLAG="-R -S"
 else
-    FOLLOW_SYMLINKS_RECURSIVELY_FLAG=--dereference-recursive
+  FOLLOW_SYMLINKS_RECURSIVELY_FLAG=--dereference-recursive
 fi
 
 if egrep \
   "\s$" \
   --line-number \
   --binary-files=without-match \
-  $FOLLOW_SYMLINKS_RECURSIVELY_FLAG \
+  ${FOLLOW_SYMLINKS_RECURSIVELY_FLAG} \
   --exclude-dir={.git,venv,node_modules} \
   ./ ; then
   echo "ERROR: Found trailing whitespace";


### PR DESCRIPTION
On macOS the functionality of the `--dereference-recursive` flag is replaced by `-R -S`; updated to fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mtlynch/tinypilot/434)
<!-- Reviewable:end -->
