### PR TITLE
Change dump-logs to just call new script

### DIFF
--- a/dev-scripts/dump-logs
+++ b/dev-scripts/dump-logs
@@ -1,78 +1,9 @@
 #!/bin/bash
 
-# Exit on unset variable.
-set -u
+# The canonical way to dump logs is through the script below,
+# but this file is here for backwards compatibility.
 
-LOG_FILE=$(mktemp)
-echo "Writing diagnostic logs to $LOG_FILE"
+# Without this file, we have no way of giving users a dump logs command
+# that will work regardless of TinyPilot version.
 
-echo "TinyPilot log dump" >> "$LOG_FILE"
-echo "https://tinypilotkvm.com" >> "$LOG_FILE"
-printf "Timestamp: %s" "$(date --iso-8601=seconds)" >> "$LOG_FILE"
-printf "\n\n" >> "$LOG_FILE"
-
-echo "Software versions" >> "$LOG_FILE"
-
-echo "Checking TinyPilot version..."
-cd /opt/tinypilot
-printf "TinyPilot version: %s %s\n" "$(git describe --tags)" "$(git rev-parse --short HEAD)" >> "$LOG_FILE"
-
-echo "Checking uStreamer version..."
-cd /opt/ustreamer
-printf "uStreamer version: %s %s\n" "$(git describe --tags)" "$(git rev-parse --short HEAD)" >> "$LOG_FILE"
-
-echo "Checking OS version..."
-printf "OS version: %s\n" "$(uname -a)" >> "$LOG_FILE"
-printf "\n" >> "$LOG_FILE"
-
-echo "Checking for voltage issues..."
-echo "voltage logs" >> "$LOG_FILE"
-sudo journalctl -xe | grep -i "voltage"  >> "$LOG_FILE"
-printf "\n" >> "$LOG_FILE"
-
-echo "Checking TinyPilot configuration..."
-printf "TinyPilot configuration\n" >> "$LOG_FILE"
-cat /lib/systemd/system/tinypilot.service >> "$LOG_FILE"
-printf "\n" >> "$LOG_FILE"
-
-echo "Checking TinyPilot logs..."
-printf "TinyPilot logs\n" >> "$LOG_FILE"
-sudo journalctl -u tinypilot | tail -n 200 >> "$LOG_FILE"
-printf "\n" >> "$LOG_FILE"
-
-echo "Checking uStreamer configuration..."
-printf "uStreamer configuration\n" >> "$LOG_FILE"
-cat /lib/systemd/system/ustreamer.service >> "$LOG_FILE"
-printf "\n" >> "$LOG_FILE"
-
-echo "Checking uStreamer logs..."
-printf "uStreamer logs\n" >> "$LOG_FILE"
-sudo journalctl -u ustreamer | tail -n 80 >> "$LOG_FILE"
-printf "\n" >> "$LOG_FILE"
-
-echo "Checking nginx logs..."
-echo "nginx logs" >> "$LOG_FILE"
-sudo journalctl -u nginx >> "$LOG_FILE"
-printf "\n\n" >> "$LOG_FILE"
-sudo tail -n 100 /var/log/nginx/error.log >> "$LOG_FILE"
-printf "\n\n" >> "$LOG_FILE"
-sudo tail -n 30 /var/log/nginx/access.log >> "$LOG_FILE"
-printf "\n" >> "$LOG_FILE"
-
-printf "Your log:\n\n"
-cat "$LOG_FILE"
-echo "-------------------------------------"
-printf "\n\n"
-
-echo -n "Upload your log file? You can review it above to see what information it contains (y/n)? "
-read answer
-printf "\n"
-if [ "$answer" != "${answer#[Yy]}" ] ;then
-    URL=$(cat "$LOG_FILE" | curl --silent --show-error --form 'sprunge=<-' http://sprunge.us)
-    printf "Copy the following URL into your bug report:\n\n\t"
-    printf "${URL}\n\n"
-else
-    echo "Log file not uploaded."
-    printf "If you decide to share it, run:\n\n"
-    printf "  cat $LOG_FILE | curl --silent --show-error --form 'sprunge=<-' http://sprunge.us\n\n"
-fi
+sudo /opt/tinypilot-privileged/collect-debug-logs


### PR DESCRIPTION
Closes https://github.com/mtlynch/tinypilot/issues/426.

Changes `dump-logs` to mimic the behavior of [`scripts/upgrade`](https://github.com/mtlynch/tinypilot/blob/e54c3bfa7a8f5ca815e9d3f804e0ce06944eb244/scripts/upgrade) in calling its replacement in `/opt/tinypilot-privileged/`.