### PR TITLE
Add GET /api/debugLogs endpoint

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -1,6 +1,3 @@
-import subprocess
-import traceback
-
 import flask
 
 import debug_logs
@@ -12,7 +9,7 @@ api_blueprint = flask.Blueprint('api', __name__, url_prefix='/api')
 
 
 @api_blueprint.route('/debugLogs', methods=['GET'])
-def debug_logs():
+def fetch_debug_logs():
     """Runs the collect-debug-logs script and returns the output to the user.
     
     Returns:

--- a/app/api.py
+++ b/app/api.py
@@ -11,7 +11,7 @@ api_blueprint = flask.Blueprint('api', __name__, url_prefix='/api')
 @api_blueprint.route('/debugLogs', methods=['GET'])
 def fetch_debug_logs():
     """Runs the collect-debug-logs script and returns the output to the user.
-    
+
     Returns:
         A text/plain response with the content of the logs in the response body.
     """

--- a/app/api.py
+++ b/app/api.py
@@ -1,3 +1,6 @@
+import subprocess
+import traceback
+
 import flask
 
 import git
@@ -5,6 +8,25 @@ import local_system
 import update
 
 api_blueprint = flask.Blueprint('api', __name__, url_prefix='/api')
+
+
+@api_blueprint.route('/debugLogs', methods=['GET'])
+def debug_logs():
+    try:
+        script_path = '/opt/tinypilot-privileged/collect-debug-logs'
+        output = subprocess.check_output([script_path, '-q'])
+        return flask.Response(output)
+    except subprocess.CalledProcessError:
+        return flask.Response(
+            'An error occurred while fetching debug logs.',
+            status=flask.status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+    except:
+        traceback.print_exc()
+        return flask.Response(
+            'An unknown error has occurred.',
+            status=flask.status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
 
 
 @api_blueprint.route('/shutdown', methods=['POST'])

--- a/app/api.py
+++ b/app/api.py
@@ -3,6 +3,7 @@ import traceback
 
 import flask
 
+import debug_logs
 import git
 import local_system
 import update
@@ -12,21 +13,17 @@ api_blueprint = flask.Blueprint('api', __name__, url_prefix='/api')
 
 @api_blueprint.route('/debugLogs', methods=['GET'])
 def debug_logs():
+    """Runs the collect-debug-logs script and returns the output to the user.
+    
+    Returns:
+        A text/plain response with the content of the logs in the response body.
+    """
     try:
-        script_path = '/opt/tinypilot-privileged/collect-debug-logs'
-        output = subprocess.check_output([script_path, '-q'])
-        return flask.Response(output)
-    except subprocess.CalledProcessError:
+        return flask.Response(debug_logs.collect())
+    except debug_logs.Error as e:
         return flask.Response(
-            'An error occurred while fetching debug logs.',
-            status=flask.status.HTTP_500_INTERNAL_SERVER_ERROR,
-        )
-    except:
-        traceback.print_exc()
-        return flask.Response(
-            'An unknown error has occurred.',
-            status=flask.status.HTTP_500_INTERNAL_SERVER_ERROR,
-        )
+            'Failed to retrieve debug logs: %s' % str(e),
+            status=flask.status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
 @api_blueprint.route('/shutdown', methods=['POST'])

--- a/app/api.py
+++ b/app/api.py
@@ -9,8 +9,8 @@ api_blueprint = flask.Blueprint('api', __name__, url_prefix='/api')
 
 
 @api_blueprint.route('/debugLogs', methods=['GET'])
-def fetch_debug_logs():
-    """Runs the collect-debug-logs script and returns the output to the user.
+def debug_logs_get():
+    """Returns the TinyPilot debug log as a plaintext HTTP response.
 
     Returns:
         A text/plain response with the content of the logs in the response body.

--- a/app/debug_logs.py
+++ b/app/debug_logs.py
@@ -1,0 +1,15 @@
+import subprocess
+import traceback
+
+
+class Error(RuntimeError):
+    pass
+
+
+def collect():
+    """Collects debug logs by running the collect-debug-logs script."""
+    try:
+        script_path = '/opt/tinypilot-privileged/collect-debug-logs'
+        return subprocess.check_output([script_path, '-q'])
+    except subprocess.CalledProcessError as e:
+        return Error(str(e))

--- a/app/debug_logs.py
+++ b/app/debug_logs.py
@@ -6,9 +6,15 @@ class Error(RuntimeError):
 
 
 def collect():
-    """Collects debug logs by running the collect-debug-logs script."""
+    """Collects and aggregates contents of TinyPilot-related logs and files.
+
+    Returns:
+        A large string with the full contents of TinyPilot's debug logs and
+        configuration files.
+    """
+
     try:
-        script_path = '/opt/tinypilot-privileged/collect-debug-logs'
-        return subprocess.check_output([script_path, '-q'])
+        return subprocess.check_output(
+            ['/opt/tinypilot-privileged/collect-debug-logs', '-q'])
     except subprocess.CalledProcessError as e:
         return Error(str(e))

--- a/app/debug_logs.py
+++ b/app/debug_logs.py
@@ -1,5 +1,4 @@
 import subprocess
-import traceback
 
 
 class Error(RuntimeError):


### PR DESCRIPTION
Closes https://github.com/mtlynch/tinypilot/issues/427.

Adds an API endpoint, `GET /api/debugLots`, that calls `collect-debug-logs` and returns its output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mtlynch/tinypilot/436)
<!-- Reviewable:end -->
