### PR TITLE
Redirect update logs to files

### DIFF
--- a/app/tests/hid/test_mouse.py
+++ b/app/tests/hid/test_mouse.py
@@ -1,7 +1,7 @@
 import tempfile
 import unittest
 
-from app.hid import mouse
+from hid import mouse
 
 
 class MouseTest(unittest.TestCase):

--- a/app/update.py
+++ b/app/update.py
@@ -1,6 +1,8 @@
 import dataclasses
+import datetime
 import enum
 import logging
+import os
 import subprocess
 import threading
 
@@ -40,7 +42,58 @@ _UPDATE_MAXIMUM_RUN_TIME = 60 * 10  # 10 minutes
 _EXIT_SUCCESS = 0
 
 
+class LoggingLevelFilter:
+    """A logging filter that only allows records at the levels we specify."""
+
+    def __init__(self, allowed_levels):
+        self._allowed_levels = allowed_levels
+
+    def filter(self, record):
+        return record.levelno in self._allowed_levels
+
+
+def _redirect_logging_to_logfiles():
+    """Set up logger to redirect output and errors to logfiles.
+
+    Sets up logger by adding handlers to make it send INFO logs to an "output"
+    file, and CRITICAL, ERROR, and WARNING logs to an "error" file."""
+
+    logs_folder = os.path.expanduser('~/logs/')
+
+    # Ensure logs folder exists.
+    try:
+        os.mkdir(logs_folder)
+    except FileExistsError:
+        pass
+
+    timestamp = datetime.datetime.now().strftime('%Y-%m-%dT%H%M%S')
+    output_file = os.path.join(logs_folder, f'{timestamp}-update-output.log')
+    error_file = os.path.join(logs_folder, f'{timestamp}-update-errors.log')
+
+    # Remove existing handlers.
+    for handler in logger.handlers:
+        logger.removeHandler(handler)
+
+    # Create an "output" handler that redirects INFO logs to output file.
+    output_handler = logging.FileHandler(output_file)
+    output_handler.setLevel(logging.INFO)
+    output_handler.addFilter(LoggingLevelFilter((logging.INFO,)))
+    logger.addHandler(output_handler)
+
+    # Create an "error" handler that redirects CRITICAL, ERROR, and WARNING
+    # logs to output file.
+    error_handler = logging.FileHandler(error_file)
+    error_handler.setLevel(logging.ERROR)
+    error_handler.addFilter(
+        LoggingLevelFilter((logging.CRITICAL, logging.ERROR, logging.WARNING)))
+    logger.addHandler(error_handler)
+
+    return error_file
+
+
 def _run_script():
+    error_file = _redirect_logging_to_logfiles()
+
     logger.info('Starting background thread to launch update process')
     _job.status = Status.IN_PROGRESS
 
@@ -55,8 +108,8 @@ def _run_script():
         if proc.returncode != _EXIT_SUCCESS:
             if isinstance(errs, bytes):
                 errs = errs.decode('utf-8')
-            logger.info('Update process returned with status code %d',
-                        proc.returncode)
+            logger.error('Update process returned with status code %d',
+                         proc.returncode)
             _job.error = errs.strip()
 
         # Set proc to none so we don't try to kill it in the finally block
@@ -65,8 +118,8 @@ def _run_script():
         logger.info('Update process timed out')
         _job.error = 'The update timed out'
     except Exception as e:  # pylint: disable=broad-except
-        logger.error('Update process met unexpected exception %s', str(e))
-        _job.error = str(e)
+        with open(error_file) as file:
+            _job.error = '\n\n'.join([str(e), 'Error logs:', file.read()])
     finally:
         if proc is not None:
             logger.info('Killing update process')


### PR DESCRIPTION
Fixes https://github.com/mtlynch/tinypilot/issues/457.

Tested locally, appears to work.

One question: it's clear the error file should only contain errors, but should the output file contain *all* the logs, or only INFO records? E.g. given

```
INFO: foo
INFO: bar
ERROR: baz
```

would the output file contain just foo and bar? Or foo, bar, and baz?