### PR TITLE
Pinning indirect dependencies of quick-install environment

### DIFF
--- a/quick-install
+++ b/quick-install
@@ -105,9 +105,18 @@ pushd "$INSTALLER_DIR"
 
 python3 -m venv venv
 . venv/bin/activate
-# Ansible depends on wheel.
-pip install wheel==0.34.2
-pip install ansible==2.9.10
+echo 'ansible==2.9.10
+cffi==1.14.4
+cryptography==3.3.1
+Jinja2==2.11.2
+MarkupSafe==1.1.1
+pkg-resources==0.0.0
+pycparser==2.20
+pyOpenSSL==20.0.1
+PyYAML==5.3.1
+six==1.15.0
+wheel==0.34.2' > requirements.txt
+pip install -r requirements.txt
 echo "[defaults]
 roles_path = $PWD
 interpreter_python = /usr/bin/python3

--- a/quick-install
+++ b/quick-install
@@ -105,7 +105,8 @@ pushd "$INSTALLER_DIR"
 
 python3 -m venv venv
 . venv/bin/activate
-echo 'ansible==2.9.10
+echo 'wheel==0.34.2
+ansible==2.9.10
 cffi==1.14.4
 cryptography==3.3.1
 Jinja2==2.11.2
@@ -114,8 +115,7 @@ pkg-resources==0.0.0
 pycparser==2.20
 pyOpenSSL==20.0.1
 PyYAML==5.3.1
-six==1.15.0
-wheel==0.34.2' > requirements.txt
+six==1.15.0' > requirements.txt
 pip install -r requirements.txt
 echo "[defaults]
 roles_path = $PWD

--- a/quick-install
+++ b/quick-install
@@ -105,8 +105,9 @@ pushd "$INSTALLER_DIR"
 
 python3 -m venv venv
 . venv/bin/activate
-echo 'wheel==0.34.2
-ansible==2.9.10
+# For some reason, wheel has to be installed before anything else.
+pip install wheel==0.34.2
+echo 'ansible==2.9.10
 cffi==1.14.4
 cryptography==3.3.1
 Jinja2==2.11.2


### PR DESCRIPTION
It looks like something changed in one of ansible's indirect dependencies recently, so now when we try to install Ansible, it fails due to a missing Rust compiler.

This fixes the issue by pinning ansible's indirect dependencies to their exact versions.