### PR TITLE
Update VS Code settings for default Python tab size

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,8 @@
   "editor.formatOnSave": true,
   "[markdown]": {
     "editor.formatOnSave": false
+  },
+  "[python]": {
+    "editor.tabSize": 4
   }
 }


### PR DESCRIPTION
4 spaces is what the style guide specifies and how YAPF formats:

https://google.github.io/styleguide/pyguide.html#34-indentation