### PR TITLE
Add support for OSLeft and OSRight keycodes

### DIFF
--- a/app/js_to_hid.py
+++ b/app/js_to_hid.py
@@ -112,6 +112,8 @@ _MAPPING = {
     'NumpadDecimal': hid.KEYCODE_NUMPAD_DOT,
     'NumpadDivide': hid.KEYCODE_NUMPAD_DIVIDE,
     'NumLock': hid.KEYCODE_NUM_LOCK,
+    'OSLeft': hid.KEYCODE_LEFT_META,
+    'OSRight': hid.KEYCODE_RIGHT_META,
     'PageUp': hid.KEYCODE_PAGE_UP,
     'PageDown': hid.KEYCODE_PAGE_DOWN,
     'Pause': hid.KEYCODE_PAUSE_BREAK,


### PR DESCRIPTION
MacOS with an English/International keyboard sends its command keys as OSLeft and OSRight instead of MetaLeft / MetaRight. This adds support for those keys so that TinyPilot treats them the same as MetaLeft and MetaRight.

Fixes #498