### PR TITLE
Fix names of custom exceptions to match style guide

### DIFF
--- a/app/debug_logs.py
+++ b/app/debug_logs.py
@@ -5,7 +5,7 @@ class Error(Exception):
     pass
 
 
-class LogCollectionScriptFailed(Error):
+class LogCollectionScriptFailedError(Error):
     pass
 
 
@@ -20,4 +20,4 @@ def collect():
         return subprocess.check_output(
             ['/opt/tinypilot-privileged/collect-debug-logs', '-q'])
     except subprocess.CalledProcessError as e:
-        raise LogCollectionScriptFailed(str(e)) from e
+        raise LogCollectionScriptFailedError(str(e)) from e

--- a/app/request_parsers/keystroke.py
+++ b/app/request_parsers/keystroke.py
@@ -5,19 +5,19 @@ class Error(Exception):
     pass
 
 
-class MissingField(Error):
+class MissingFieldError(Error):
     pass
 
 
-class InvalidModifierKey(Error):
+class InvalidModifierKeyError(Error):
     pass
 
 
-class InvalidKeyCode(Error):
+class InvalidKeyCodeError(Error):
     pass
 
 
-class InvalidLocation(Error):
+class InvalidLocationError(Error):
     pass
 
 
@@ -34,7 +34,7 @@ class Keystroke:
 
 def parse_keystroke(message):
     if not isinstance(message, dict):
-        raise MissingField(
+        raise MissingFieldError(
             'Keystroke parameter is invalid, expecting a dictionary data type')
     required_fields = (
         'key',
@@ -47,7 +47,7 @@ def parse_keystroke(message):
     )
     for field in required_fields:
         if field not in message:
-            raise MissingField(
+            raise MissingFieldError(
                 'Keystroke request is missing required field: %s' % field)
     return Keystroke(
         left_ctrl_modifier=_parse_modifier_key(message['ctrlKey']),
@@ -61,16 +61,16 @@ def parse_keystroke(message):
 
 def _parse_modifier_key(modifier_key):
     if not isinstance(modifier_key, bool):
-        raise InvalidModifierKey('Modifier keys must be boolean values: %s' %
-                                 modifier_key)
+        raise InvalidModifierKeyError(
+            'Modifier keys must be boolean values: %s' % modifier_key)
     return modifier_key
 
 
 def _parse_code(code):
     if not isinstance(code, str):
-        raise InvalidKeyCode('Key code must be a string: %s' % code)
+        raise InvalidKeyCodeError('Key code must be a string: %s' % code)
 
     # Arbitrary limit, but just to prevent anything crazy.
     if len(code) > 30:
-        raise InvalidKeyCode('Key code is too long: %s' % code)
+        raise InvalidKeyCodeError('Key code is too long: %s' % code)
     return code

--- a/app/request_parsers/keystroke_test.py
+++ b/app/request_parsers/keystroke_test.py
@@ -94,7 +94,7 @@ class KeystrokeTest(unittest.TestCase):
             }))
 
     def test_rejects_invalid_meta_modifier(self):
-        with self.assertRaises(keystroke.InvalidModifierKey):
+        with self.assertRaises(keystroke.InvalidModifierKeyError):
             keystroke.parse_keystroke({
                 'metaKey': 'banana',
                 'altKey': False,
@@ -106,7 +106,7 @@ class KeystrokeTest(unittest.TestCase):
             })
 
     def test_rejects_invalid_alt_modifier(self):
-        with self.assertRaises(keystroke.InvalidModifierKey):
+        with self.assertRaises(keystroke.InvalidModifierKeyError):
             keystroke.parse_keystroke({
                 'metaKey': False,
                 'altKey': 'banana',
@@ -118,7 +118,7 @@ class KeystrokeTest(unittest.TestCase):
             })
 
     def test_rejects_invalid_shift_modifier(self):
-        with self.assertRaises(keystroke.InvalidModifierKey):
+        with self.assertRaises(keystroke.InvalidModifierKeyError):
             keystroke.parse_keystroke({
                 'metaKey': False,
                 'altKey': False,
@@ -130,7 +130,7 @@ class KeystrokeTest(unittest.TestCase):
             })
 
     def test_rejects_invalid_ctrl_modifier(self):
-        with self.assertRaises(keystroke.InvalidModifierKey):
+        with self.assertRaises(keystroke.InvalidModifierKeyError):
             keystroke.parse_keystroke({
                 'metaKey': False,
                 'altKey': False,
@@ -142,7 +142,7 @@ class KeystrokeTest(unittest.TestCase):
             })
 
     def test_rejects_invalid_alt_graph_modifier(self):
-        with self.assertRaises(keystroke.InvalidModifierKey):
+        with self.assertRaises(keystroke.InvalidModifierKeyError):
             keystroke.parse_keystroke({
                 'metaKey': False,
                 'altKey': False,
@@ -154,7 +154,7 @@ class KeystrokeTest(unittest.TestCase):
             })
 
     def test_rejects_float_keycode_value(self):
-        with self.assertRaises(keystroke.InvalidKeyCode):
+        with self.assertRaises(keystroke.InvalidKeyCodeError):
             keystroke.parse_keystroke({
                 'metaKey': False,
                 'altKey': False,
@@ -166,7 +166,7 @@ class KeystrokeTest(unittest.TestCase):
             })
 
     def test_rejects_missing_meta_key_value(self):
-        with self.assertRaises(keystroke.MissingField):
+        with self.assertRaises(keystroke.MissingFieldError):
             keystroke.parse_keystroke({
                 'altKey': False,
                 'shiftKey': False,
@@ -177,7 +177,7 @@ class KeystrokeTest(unittest.TestCase):
             })
 
     def test_rejects_missing_alt_key_value(self):
-        with self.assertRaises(keystroke.MissingField):
+        with self.assertRaises(keystroke.MissingFieldError):
             keystroke.parse_keystroke({
                 'metaKey': False,
                 'shiftKey': False,
@@ -188,7 +188,7 @@ class KeystrokeTest(unittest.TestCase):
             })
 
     def test_rejects_missing_alt_graph_key_value(self):
-        with self.assertRaises(keystroke.MissingField):
+        with self.assertRaises(keystroke.MissingFieldError):
             keystroke.parse_keystroke({
                 'altKey': False,
                 'metaKey': False,
@@ -199,7 +199,7 @@ class KeystrokeTest(unittest.TestCase):
             })
 
     def test_rejects_missing_shift_key_value(self):
-        with self.assertRaises(keystroke.MissingField):
+        with self.assertRaises(keystroke.MissingFieldError):
             keystroke.parse_keystroke({
                 'metaKey': False,
                 'altKey': False,
@@ -210,7 +210,7 @@ class KeystrokeTest(unittest.TestCase):
             })
 
     def test_rejects_missing_ctrl_key_value(self):
-        with self.assertRaises(keystroke.MissingField):
+        with self.assertRaises(keystroke.MissingFieldError):
             keystroke.parse_keystroke({
                 'metaKey': False,
                 'altKey': False,
@@ -221,7 +221,7 @@ class KeystrokeTest(unittest.TestCase):
             })
 
     def test_rejects_missing_key_value(self):
-        with self.assertRaises(keystroke.MissingField):
+        with self.assertRaises(keystroke.MissingFieldError):
             keystroke.parse_keystroke({
                 'metaKey': False,
                 'altKey': False,
@@ -232,7 +232,7 @@ class KeystrokeTest(unittest.TestCase):
             })
 
     def test_rejects_missing_code_value(self):
-        with self.assertRaises(keystroke.MissingField):
+        with self.assertRaises(keystroke.MissingFieldError):
             keystroke.parse_keystroke({
                 'metaKey': False,
                 'altKey': False,
@@ -243,7 +243,7 @@ class KeystrokeTest(unittest.TestCase):
             })
 
     def test_rejects_too_long_code_value(self):
-        with self.assertRaises(keystroke.InvalidKeyCode):
+        with self.assertRaises(keystroke.InvalidKeyCodeError):
             keystroke.parse_keystroke({
                 'metaKey': False,
                 'altKey': False,

--- a/app/request_parsers/mouse_event.py
+++ b/app/request_parsers/mouse_event.py
@@ -5,19 +5,19 @@ class Error(Exception):
     pass
 
 
-class MissingField(Error):
+class MissingFieldError(Error):
     pass
 
 
-class InvalidButtonState(Error):
+class InvalidButtonStateError(Error):
     pass
 
 
-class InvalidRelativePosition(Error):
+class InvalidRelativePositionError(Error):
     pass
 
 
-class InvalidWheelValue(Error):
+class InvalidWheelValueError(Error):
     pass
 
 
@@ -47,14 +47,14 @@ class MouseEvent:
 
 def parse_mouse_event(message):
     if not isinstance(message, dict):
-        raise MissingField(
+        raise MissingFieldError(
             'Mouse event parameter is invalid, expecting a dictionary data type'
         )
     required_fields = ('buttons', 'relativeX', 'relativeY',
                        'verticalWheelDelta', 'horizontalWheelDelta')
     for field in required_fields:
         if field not in message:
-            raise MissingField(
+            raise MissingFieldError(
                 'Mouse event request is missing required field: %s' % field)
     return MouseEvent(
         buttons=_parse_button_state(message['buttons']),
@@ -68,22 +68,22 @@ def parse_mouse_event(message):
 
 def _parse_button_state(buttons):
     if not isinstance(buttons, int):
-        raise InvalidButtonState('Button state must be an integer value: %s' %
-                                 buttons)
+        raise InvalidButtonStateError(
+            'Button state must be an integer value: %s' % buttons)
     if not (0 <= buttons <= _MAX_BUTTON_STATE):
-        raise InvalidButtonState('Button state must be <= 0x%x: %s' %
-                                 (_MAX_BUTTON_STATE, buttons))
+        raise InvalidButtonStateError('Button state must be <= 0x%x: %s' %
+                                      (_MAX_BUTTON_STATE, buttons))
     return buttons
 
 
 def _parse_relative_position(relative_position):
     if not isinstance(relative_position, float) and not isinstance(
             relative_position, int):
-        raise InvalidRelativePosition(
+        raise InvalidRelativePositionError(
             'Relative position must be a float between 0.0 and 1.0: %s' %
             relative_position)
     if not (0.0 <= relative_position <= 1.0):
-        raise InvalidRelativePosition(
+        raise InvalidRelativePositionError(
             'Relative position must be a float between 0.0 and 1.0: %s' %
             relative_position)
     return relative_position
@@ -91,8 +91,9 @@ def _parse_relative_position(relative_position):
 
 def _parse_wheel_value(wheel_value):
     if not isinstance(wheel_value, int):
-        raise InvalidWheelValue('Wheel value must be a int: %s' % wheel_value)
+        raise InvalidWheelValueError('Wheel value must be a int: %s' %
+                                     wheel_value)
     if wheel_value not in (-1, 0, 1):
-        raise InvalidWheelValue('Wheel value must be -1, 0, or 1: %s' %
-                                wheel_value)
+        raise InvalidWheelValueError('Wheel value must be -1, 0, or 1: %s' %
+                                     wheel_value)
     return wheel_value

--- a/app/request_parsers/mouse_event_test.py
+++ b/app/request_parsers/mouse_event_test.py
@@ -111,7 +111,7 @@ class MouseEventTest(unittest.TestCase):
             }))
 
     def test_rejects_negative_buttons_value(self):
-        with self.assertRaises(mouse_event.InvalidButtonState):
+        with self.assertRaises(mouse_event.InvalidButtonStateError):
             mouse_event.parse_mouse_event({
                 'buttons': -1,
                 'relativeX': 0.5,
@@ -121,7 +121,7 @@ class MouseEventTest(unittest.TestCase):
             })
 
     def test_rejects_too_high_buttons_value(self):
-        with self.assertRaises(mouse_event.InvalidButtonState):
+        with self.assertRaises(mouse_event.InvalidButtonStateError):
             mouse_event.parse_mouse_event({
                 'buttons': 32,
                 'relativeX': 0.5,
@@ -131,7 +131,7 @@ class MouseEventTest(unittest.TestCase):
             })
 
     def test_rejects_non_numeric_buttons_value(self):
-        with self.assertRaises(mouse_event.InvalidButtonState):
+        with self.assertRaises(mouse_event.InvalidButtonStateError):
             mouse_event.parse_mouse_event({
                 'buttons': 'a',
                 'relativeX': 0.5,
@@ -141,7 +141,7 @@ class MouseEventTest(unittest.TestCase):
             })
 
     def test_rejects_negative_relative_x_value(self):
-        with self.assertRaises(mouse_event.InvalidRelativePosition):
+        with self.assertRaises(mouse_event.InvalidRelativePositionError):
             mouse_event.parse_mouse_event({
                 'buttons': 0,
                 'relativeX': -0.001,
@@ -151,7 +151,7 @@ class MouseEventTest(unittest.TestCase):
             })
 
     def test_rejects_negative_relative_y_value(self):
-        with self.assertRaises(mouse_event.InvalidRelativePosition):
+        with self.assertRaises(mouse_event.InvalidRelativePositionError):
             mouse_event.parse_mouse_event({
                 'buttons': 0,
                 'relativeX': 0.5,
@@ -161,7 +161,7 @@ class MouseEventTest(unittest.TestCase):
             })
 
     def test_rejects_too_high_relative_x_value(self):
-        with self.assertRaises(mouse_event.InvalidRelativePosition):
+        with self.assertRaises(mouse_event.InvalidRelativePositionError):
             mouse_event.parse_mouse_event({
                 'buttons': 0,
                 'relativeX': 1.001,
@@ -171,7 +171,7 @@ class MouseEventTest(unittest.TestCase):
             })
 
     def test_rejects_too_high_relative_y_value(self):
-        with self.assertRaises(mouse_event.InvalidRelativePosition):
+        with self.assertRaises(mouse_event.InvalidRelativePositionError):
             mouse_event.parse_mouse_event({
                 'buttons': 0,
                 'relativeX': 0.5,
@@ -181,7 +181,7 @@ class MouseEventTest(unittest.TestCase):
             })
 
     def test_rejects_non_float_relative_x_value(self):
-        with self.assertRaises(mouse_event.InvalidRelativePosition):
+        with self.assertRaises(mouse_event.InvalidRelativePositionError):
             mouse_event.parse_mouse_event({
                 'buttons': 0,
                 'relativeX': 'a',
@@ -191,7 +191,7 @@ class MouseEventTest(unittest.TestCase):
             })
 
     def test_rejects_non_float_relative_y_value(self):
-        with self.assertRaises(mouse_event.InvalidRelativePosition):
+        with self.assertRaises(mouse_event.InvalidRelativePositionError):
             mouse_event.parse_mouse_event({
                 'buttons': 0,
                 'relativeX': 0.5,
@@ -201,7 +201,7 @@ class MouseEventTest(unittest.TestCase):
             })
 
     def test_rejects_missing_buttons_field(self):
-        with self.assertRaises(mouse_event.MissingField):
+        with self.assertRaises(mouse_event.MissingFieldError):
             mouse_event.parse_mouse_event({
                 'relativeX': 0,
                 'relativeY': 0,
@@ -210,7 +210,7 @@ class MouseEventTest(unittest.TestCase):
             })
 
     def test_rejects_missing_relative_x_field(self):
-        with self.assertRaises(mouse_event.MissingField):
+        with self.assertRaises(mouse_event.MissingFieldError):
             mouse_event.parse_mouse_event({
                 'buttons': 0,
                 'relativeY': 0,
@@ -219,7 +219,7 @@ class MouseEventTest(unittest.TestCase):
             })
 
     def test_rejects_missing_relative_y_field(self):
-        with self.assertRaises(mouse_event.MissingField):
+        with self.assertRaises(mouse_event.MissingFieldError):
             mouse_event.parse_mouse_event({
                 'buttons': 0,
                 'relativeX': 0,
@@ -228,7 +228,7 @@ class MouseEventTest(unittest.TestCase):
             })
 
     def test_rejects_missing_vertical_wheel_field(self):
-        with self.assertRaises(mouse_event.MissingField):
+        with self.assertRaises(mouse_event.MissingFieldError):
             mouse_event.parse_mouse_event({
                 'buttons': 0,
                 'relativeX': 0,
@@ -236,7 +236,7 @@ class MouseEventTest(unittest.TestCase):
             })
 
     def test_rejects_missing_horizontal_wheel_field(self):
-        with self.assertRaises(mouse_event.MissingField):
+        with self.assertRaises(mouse_event.MissingFieldError):
             mouse_event.parse_mouse_event({
                 'buttons': 0,
                 'relativeX': 0,
@@ -244,7 +244,7 @@ class MouseEventTest(unittest.TestCase):
             })
 
     def test_rejects_string_vertical_wheel_value(self):
-        with self.assertRaises(mouse_event.InvalidWheelValue):
+        with self.assertRaises(mouse_event.InvalidWheelValueError):
             mouse_event.parse_mouse_event({
                 'buttons': 0,
                 'relativeX': 0.5,
@@ -254,7 +254,7 @@ class MouseEventTest(unittest.TestCase):
             })
 
     def test_rejects_float_vertical_wheel_value(self):
-        with self.assertRaises(mouse_event.InvalidWheelValue):
+        with self.assertRaises(mouse_event.InvalidWheelValueError):
             mouse_event.parse_mouse_event({
                 'buttons': 0,
                 'relativeX': 0.5,
@@ -264,7 +264,7 @@ class MouseEventTest(unittest.TestCase):
             })
 
     def test_rejects_too_high_vertical_wheel_value(self):
-        with self.assertRaises(mouse_event.InvalidWheelValue):
+        with self.assertRaises(mouse_event.InvalidWheelValueError):
             mouse_event.parse_mouse_event({
                 'buttons': 0,
                 'relativeX': 0.5,
@@ -274,7 +274,7 @@ class MouseEventTest(unittest.TestCase):
             })
 
     def test_rejects_too_low_vertical_wheel_value(self):
-        with self.assertRaises(mouse_event.InvalidWheelValue):
+        with self.assertRaises(mouse_event.InvalidWheelValueError):
             mouse_event.parse_mouse_event({
                 'buttons': 0,
                 'relativeX': 0.5,
@@ -284,7 +284,7 @@ class MouseEventTest(unittest.TestCase):
             })
 
     def test_rejects_string_horizontal_wheel_value(self):
-        with self.assertRaises(mouse_event.InvalidWheelValue):
+        with self.assertRaises(mouse_event.InvalidWheelValueError):
             mouse_event.parse_mouse_event({
                 'buttons': 0,
                 'relativeX': 0.5,
@@ -294,7 +294,7 @@ class MouseEventTest(unittest.TestCase):
             })
 
     def test_rejects_float_horizontal_wheel_value(self):
-        with self.assertRaises(mouse_event.InvalidWheelValue):
+        with self.assertRaises(mouse_event.InvalidWheelValueError):
             mouse_event.parse_mouse_event({
                 'buttons': 0,
                 'relativeX': 0.5,
@@ -304,7 +304,7 @@ class MouseEventTest(unittest.TestCase):
             })
 
     def test_rejects_too_high_horizontal_wheel_value(self):
-        with self.assertRaises(mouse_event.InvalidWheelValue):
+        with self.assertRaises(mouse_event.InvalidWheelValueError):
             mouse_event.parse_mouse_event({
                 'buttons': 0,
                 'relativeX': 0.5,
@@ -314,7 +314,7 @@ class MouseEventTest(unittest.TestCase):
             })
 
     def test_rejects_too_low_horizontal_wheel_value(self):
-        with self.assertRaises(mouse_event.InvalidWheelValue):
+        with self.assertRaises(mouse_event.InvalidWheelValueError):
             mouse_event.parse_mouse_event({
                 'buttons': 0,
                 'relativeX': 0.5,


### PR DESCRIPTION
>Libraries or packages may define their own exceptions. When doing so they must inherit from an existing exception class. Exception names should end in Error and should not introduce stutter (foo.FooError).

https://google.github.io/styleguide/pyguide.html#24-exceptions
