### PR TITLE
Add support for a TinyPilot Ansible vars file in quick-install 

### DIFF
--- a/quick-install
+++ b/quick-install
@@ -57,7 +57,7 @@ echo "Final install vars: $TINYPILOT_INSTALL_VARS"
 # Check if there's a settings file with extra installation settings.
 readonly TINYPILOT_SETTINGS_FILE="/home/tinypilot/settings.yml"
 EXTRA_VARS_PATH=""
-if [ !-f "${TINYPILOT_SETTINGS_FILE}" ]; then
+if [ -f "${TINYPILOT_SETTINGS_FILE}" ]; then
   echo "Using settings file at: ${TINYPILOT_SETTINGS_FILE}"
   EXTRA_VARS_PATH="@${TINYPILOT_SETTINGS_FILE}"
 else

--- a/quick-install
+++ b/quick-install
@@ -11,6 +11,9 @@ else
   echo "User-specified install vars: $TINYPILOT_INSTALL_VARS"
 fi
 
+# TODO(mtlynch): Move the TINYPILOT_INSTALL_VARS logic into
+#   TINYPILOT_SETTINGS_FILE vars.
+
 # Check if this system uses the TC358743 HDMI to CSI capture bridge.
 USE_TC358743_DEFAULTS=''
 if [[ "$TINYPILOT_INSTALL_VARS" =~ 'ustreamer_capture_device=' ]]; then
@@ -50,6 +53,18 @@ set -u
 set -e
 
 echo "Final install vars: $TINYPILOT_INSTALL_VARS"
+
+# Check if there's a settings file with extra installation settings.
+readonly TINYPILOT_SETTINGS_FILE="/home/tinypilot/settings.yml"
+EXTRA_VARS_PATH=""
+if [ !-f "${TINYPILOT_SETTINGS_FILE}" ]; then
+  echo "Using settings file at: ${TINYPILOT_SETTINGS_FILE}"
+  EXTRA_VARS_PATH="@${TINYPILOT_SETTINGS_FILE}"
+else
+  echo "No pre-existing settings file found at: ${TINYPILOT_SETTINGS_FILE}"
+  EXTRA_VARS_PATH=""
+fi
+readonly EXTRA_VARS_PATH
 
 # Check if the user is accidentally downgrading from TinyPilot Pro.
 HAS_PRO_INSTALLED=0
@@ -143,4 +158,6 @@ echo "- hosts: localhost
   become_method: sudo
   roles:
     - role: $TINYPILOT_ROLE_NAME" > install.yml
-ansible-playbook -i localhost, install.yml --extra-vars "$TINYPILOT_INSTALL_VARS"
+ansible-playbook -i localhost, install.yml \
+  --extra-vars "${EXTRA_VARS_PATH}"
+  --extra-vars "${TINYPILOT_INSTALL_VARS}"

--- a/quick-install
+++ b/quick-install
@@ -159,5 +159,5 @@ echo "- hosts: localhost
   roles:
     - role: $TINYPILOT_ROLE_NAME" > install.yml
 ansible-playbook -i localhost, install.yml \
-  --extra-vars "${EXTRA_VARS_PATH}"
+  --extra-vars "${EXTRA_VARS_PATH}" \
   --extra-vars "${TINYPILOT_INSTALL_VARS}"


### PR DESCRIPTION
This will offer a cleaner way for users to persist settings across updates.