### PR TITLE
Add --force to ansible-galaxy install

### DIFF
--- a/quick-install
+++ b/quick-install
@@ -133,7 +133,9 @@ else
   git clone "$TINYPILOT_ROLE_REPO" "$TINYPILOT_ROLE_NAME"
 fi
 
-ansible-galaxy install --role-file "${TINYPILOT_ROLE_NAME}/requirements.yml"
+ansible-galaxy install \
+  --force \
+  --role-file "${TINYPILOT_ROLE_NAME}/requirements.yml"
 
 echo "- hosts: localhost
   connection: local


### PR DESCRIPTION
Otherwise, ansible uses the cached version regardless of whether the remote has updated or if the local version doesn't match the requirement.