### PR TITLE
Fix names of custom exceptions to match style guide

### DIFF
--- a/app/request_parsers/errors.py
+++ b/app/request_parsers/errors.py
@@ -2,13 +2,13 @@ class Error(Exception):
     pass
 
 
-class MalformedRequest(Error):
+class MalformedRequestError(Error):
     pass
 
 
-class MissingField(Error):
+class MissingFieldError(Error):
     pass
 
 
-class InvalidHostname(Error):
+class InvalidHostnameError(Error):
     pass

--- a/app/request_parsers/hostname.py
+++ b/app/request_parsers/hostname.py
@@ -7,7 +7,7 @@ def parse_hostname(request):
     message = message_parser.parse_message(request, ['hostname'])
     hostname = message['hostname']
     if not hostname_validator.validate(hostname):
-        raise errors.InvalidHostname(
+        raise errors.InvalidHostnameError(
             'Hostnames can only contain the letters a-z, digits and dashes'
             ' (it cannot start with a dash, though).')
     return hostname

--- a/app/request_parsers/keystroke.py
+++ b/app/request_parsers/keystroke.py
@@ -5,7 +5,7 @@ class Error(Exception):
     pass
 
 
-class MissingFieldError(Error):
+class MissingFieldErrorError(Error):
     pass
 
 
@@ -34,7 +34,7 @@ class Keystroke:
 
 def parse_keystroke(message):
     if not isinstance(message, dict):
-        raise MissingFieldError(
+        raise MissingFieldErrorError(
             'Keystroke parameter is invalid, expecting a dictionary data type')
     required_fields = (
         'key',
@@ -47,7 +47,7 @@ def parse_keystroke(message):
     )
     for field in required_fields:
         if field not in message:
-            raise MissingFieldError(
+            raise MissingFieldErrorError(
                 'Keystroke request is missing required field: %s' % field)
     return Keystroke(
         left_ctrl_modifier=_parse_modifier_key(message['ctrlKey']),

--- a/app/request_parsers/keystroke_test.py
+++ b/app/request_parsers/keystroke_test.py
@@ -166,7 +166,7 @@ class KeystrokeTest(unittest.TestCase):
             })
 
     def test_rejects_missing_meta_key_value(self):
-        with self.assertRaises(keystroke.MissingFieldError):
+        with self.assertRaises(keystroke.MissingFieldErrorError):
             keystroke.parse_keystroke({
                 'altKey': False,
                 'shiftKey': False,
@@ -177,7 +177,7 @@ class KeystrokeTest(unittest.TestCase):
             })
 
     def test_rejects_missing_alt_key_value(self):
-        with self.assertRaises(keystroke.MissingFieldError):
+        with self.assertRaises(keystroke.MissingFieldErrorError):
             keystroke.parse_keystroke({
                 'metaKey': False,
                 'shiftKey': False,
@@ -188,7 +188,7 @@ class KeystrokeTest(unittest.TestCase):
             })
 
     def test_rejects_missing_alt_graph_key_value(self):
-        with self.assertRaises(keystroke.MissingFieldError):
+        with self.assertRaises(keystroke.MissingFieldErrorError):
             keystroke.parse_keystroke({
                 'altKey': False,
                 'metaKey': False,
@@ -199,7 +199,7 @@ class KeystrokeTest(unittest.TestCase):
             })
 
     def test_rejects_missing_shift_key_value(self):
-        with self.assertRaises(keystroke.MissingFieldError):
+        with self.assertRaises(keystroke.MissingFieldErrorError):
             keystroke.parse_keystroke({
                 'metaKey': False,
                 'altKey': False,
@@ -210,7 +210,7 @@ class KeystrokeTest(unittest.TestCase):
             })
 
     def test_rejects_missing_ctrl_key_value(self):
-        with self.assertRaises(keystroke.MissingFieldError):
+        with self.assertRaises(keystroke.MissingFieldErrorError):
             keystroke.parse_keystroke({
                 'metaKey': False,
                 'altKey': False,
@@ -221,7 +221,7 @@ class KeystrokeTest(unittest.TestCase):
             })
 
     def test_rejects_missing_key_value(self):
-        with self.assertRaises(keystroke.MissingFieldError):
+        with self.assertRaises(keystroke.MissingFieldErrorError):
             keystroke.parse_keystroke({
                 'metaKey': False,
                 'altKey': False,
@@ -232,7 +232,7 @@ class KeystrokeTest(unittest.TestCase):
             })
 
     def test_rejects_missing_code_value(self):
-        with self.assertRaises(keystroke.MissingFieldError):
+        with self.assertRaises(keystroke.MissingFieldErrorError):
             keystroke.parse_keystroke({
                 'metaKey': False,
                 'altKey': False,

--- a/app/request_parsers/message.py
+++ b/app/request_parsers/message.py
@@ -15,11 +15,11 @@ def parse_message(request, required_fields):
     message = request.get_json()
 
     if not isinstance(message, dict):
-        raise errors.MalformedRequest(
+        raise errors.MalformedRequestError(
             'Request is invalid, expecting a JSON dictionary')
 
     for field in required_fields:
         if field not in message:
-            raise errors.MissingField('Missing required field: %s' % field)
+            raise errors.MissingFieldError('Missing required field: %s' % field)
 
     return message

--- a/app/request_parsers/mouse_event.py
+++ b/app/request_parsers/mouse_event.py
@@ -5,7 +5,7 @@ class Error(Exception):
     pass
 
 
-class MissingFieldError(Error):
+class MissingFieldErrorError(Error):
     pass
 
 
@@ -47,14 +47,14 @@ class MouseEvent:
 
 def parse_mouse_event(message):
     if not isinstance(message, dict):
-        raise MissingFieldError(
+        raise MissingFieldErrorError(
             'Mouse event parameter is invalid, expecting a dictionary data type'
         )
     required_fields = ('buttons', 'relativeX', 'relativeY',
                        'verticalWheelDelta', 'horizontalWheelDelta')
     for field in required_fields:
         if field not in message:
-            raise MissingFieldError(
+            raise MissingFieldErrorError(
                 'Mouse event request is missing required field: %s' % field)
     return MouseEvent(
         buttons=_parse_button_state(message['buttons']),

--- a/app/request_parsers/mouse_event_test.py
+++ b/app/request_parsers/mouse_event_test.py
@@ -201,7 +201,7 @@ class MouseEventTest(unittest.TestCase):
             })
 
     def test_rejects_missing_buttons_field(self):
-        with self.assertRaises(mouse_event.MissingFieldError):
+        with self.assertRaises(mouse_event.MissingFieldErrorError):
             mouse_event.parse_mouse_event({
                 'relativeX': 0,
                 'relativeY': 0,
@@ -210,7 +210,7 @@ class MouseEventTest(unittest.TestCase):
             })
 
     def test_rejects_missing_relative_x_field(self):
-        with self.assertRaises(mouse_event.MissingFieldError):
+        with self.assertRaises(mouse_event.MissingFieldErrorError):
             mouse_event.parse_mouse_event({
                 'buttons': 0,
                 'relativeY': 0,
@@ -219,7 +219,7 @@ class MouseEventTest(unittest.TestCase):
             })
 
     def test_rejects_missing_relative_y_field(self):
-        with self.assertRaises(mouse_event.MissingFieldError):
+        with self.assertRaises(mouse_event.MissingFieldErrorError):
             mouse_event.parse_mouse_event({
                 'buttons': 0,
                 'relativeX': 0,
@@ -228,7 +228,7 @@ class MouseEventTest(unittest.TestCase):
             })
 
     def test_rejects_missing_vertical_wheel_field(self):
-        with self.assertRaises(mouse_event.MissingFieldError):
+        with self.assertRaises(mouse_event.MissingFieldErrorError):
             mouse_event.parse_mouse_event({
                 'buttons': 0,
                 'relativeX': 0,
@@ -236,7 +236,7 @@ class MouseEventTest(unittest.TestCase):
             })
 
     def test_rejects_missing_horizontal_wheel_field(self):
-        with self.assertRaises(mouse_event.MissingFieldError):
+        with self.assertRaises(mouse_event.MissingFieldErrorError):
             mouse_event.parse_mouse_event({
                 'buttons': 0,
                 'relativeX': 0,


### PR DESCRIPTION
These new names were backported from TinyPilot Pro, which didn't have the fixes from #516 yet

>Libraries or packages may define their own exceptions. When doing so they must inherit from an existing exception class. Exception names should end in Error and should not introduce stutter (foo.FooError).

https://google.github.io/styleguide/pyguide.html#24-exceptions