### PR TITLE
Add frontend for changing the device hostname

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -229,9 +229,9 @@ def status_get():
             'error': null
         }
     """
-    resp = _json_success()
-    resp.headers['Access-Control-Allow-Origin'] = '*'
-    return resp
+    response = _json_success()
+    response.headers['Access-Control-Allow-Origin'] = '*'
+    return response
 
 
 # The default dictionary is okay because we're not modifying it.

--- a/app/api.py
+++ b/app/api.py
@@ -213,6 +213,27 @@ def hostname_set():
         return _json_error('Operation failed: %s' % str(e)), 200
 
 
+@api_blueprint.route('/status', methods=['GET'])
+def status_get():
+    """Checks the status of TinyPilot.
+
+    This endpoint may be called from all locations, so there is no restriction
+    in regards to CORS.
+
+    Returns:
+        A JSON string with two keys: success, error.
+
+        Example:
+        {
+            'success': true,
+            'error': null
+        }
+    """
+    resp = _json_success()
+    resp.headers['Access-Control-Allow-Origin'] = '*'
+    return resp
+
+
 # The default dictionary is okay because we're not modifying it.
 # pylint: disable=dangerous-default-value
 def _json_success(fields={}):

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -314,10 +314,7 @@ document
     showError(evt.detail.summary, evt.detail.detail);
   });
 document.getElementById("change-hostname-btn").addEventListener("click", () => {
-  const changeHostnameDialog = document.getElementById(
-    "change-hostname-dialog"
-  );
-  changeHostnameDialog.show = true;
+  document.getElementById("change-hostname-dialog").show = true;
 });
 document
   .getElementById("change-hostname-dialog")

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -313,6 +313,17 @@ document
   .addEventListener("update-failure", (evt) => {
     showError(evt.detail.summary, evt.detail.detail);
   });
+document.getElementById("change-hostname-btn").addEventListener("click", () => {
+  const changeHostnameDialog = document.getElementById(
+    "change-hostname-dialog"
+  );
+  changeHostnameDialog.show = true;
+});
+document
+  .getElementById("change-hostname-dialog")
+  .addEventListener("change-hostname-failure", (evt) => {
+    showError(evt.detail.summary, evt.detail.detail);
+  });
 document
   .getElementById("paste-overlay")
   .addEventListener("paste-text", (evt) => {

--- a/app/static/js/controllers.js
+++ b/app/static/js/controllers.js
@@ -214,6 +214,58 @@
       });
   }
 
+  function determineHostname() {
+    const route = "/api/hostname";
+    return fetch(route, {
+      method: "GET",
+      mode: "same-origin",
+      cache: "no-cache",
+      redirect: "error",
+    })
+      .then((response) => {
+        return readHttpJsonResponse(response);
+      })
+      .then((jsonResponse) => {
+        return checkJsonSuccess(jsonResponse);
+      })
+      .then((hostnameResponse) => {
+        if (!hostnameResponse.hasOwnProperty("hostname")) {
+          return Promise.reject(new Error("Missing expected hostname field"));
+        }
+        return Promise.resolve(hostnameResponse.hostname);
+      })
+      .catch((error) => {
+        return Promise.reject(error);
+      });
+  }
+
+  function changeHostname(newHostname) {
+    const route = "/api/hostname";
+    return fetch(route, {
+      method: "PUT",
+      mode: "same-origin",
+      cache: "no-cache",
+      redirect: "error",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRFToken": getCsrfToken(),
+      },
+      body: JSON.stringify({ hostname: newHostname }),
+    })
+      .then((response) => {
+        return readHttpJsonResponse(response);
+      })
+      .then((jsonResponse) => {
+        return checkJsonSuccess(jsonResponse);
+      })
+      .then(() => {
+        return Promise.resolve(newHostname);
+      })
+      .catch((error) => {
+        return Promise.reject(error);
+      });
+  }
+
   if (!window.hasOwnProperty("controllers")) {
     window.controllers = {};
   }
@@ -223,4 +275,6 @@
   window.controllers.shutdown = shutdown;
   window.controllers.update = update;
   window.controllers.getUpdateStatus = getUpdateStatus;
+  window.controllers.determineHostname = determineHostname;
+  window.controllers.changeHostname = changeHostname;
 })(window);

--- a/app/static/js/controllers.js
+++ b/app/static/js/controllers.js
@@ -266,6 +266,28 @@
       });
   }
 
+  function checkStatus(baseURL) {
+    const route = "/api/status";
+    return fetch(baseURL + route, {
+      method: "GET",
+      mode: "cors",
+      cache: "no-cache",
+      redirect: "error",
+    })
+      .then((response) => {
+        return readHttpJsonResponse(response);
+      })
+      .then((jsonResponse) => {
+        return checkJsonSuccess(jsonResponse);
+      })
+      .then(() => {
+        return Promise.resolve(true);
+      })
+      .catch((error) => {
+        return Promise.reject(error);
+      });
+  }
+
   if (!window.hasOwnProperty("controllers")) {
     window.controllers = {};
   }
@@ -277,4 +299,5 @@
   window.controllers.getUpdateStatus = getUpdateStatus;
   window.controllers.determineHostname = determineHostname;
   window.controllers.changeHostname = changeHostname;
+  window.controllers.checkStatus = checkStatus;
 })(window);

--- a/app/templates/components/navbar.html
+++ b/app/templates/components/navbar.html
@@ -22,6 +22,9 @@
         <li>
           <a id="update-btn">Update</a>
         </li>
+        <li>
+          <a id="change-hostname-btn">Change hostname</a>
+        </li>
       </ul>
     </li>
 

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -306,7 +306,10 @@
           // might require additional time for the new hostname to propagate.
           poll({
             fn: async () => {
-              const response = await fetch(futureLocation);
+              const response = await fetch(futureLocation, {
+                // Disable CORS as we only send a “ping” here
+                mode: "no-cors",
+              });
               return response.status;
             },
             validate: (status) => status === 200,

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -302,7 +302,7 @@
         }
 
         waitForReboot(futureLocation) {
-          // Try to reach the future location for a total of 120 seconds.
+          // Try to reach the future location for a total of 180 seconds.
           // Note: it’s not enough to just wait for the mere reboot, but it
           // might require additional time for the new hostname to propagate.
           return poll({
@@ -314,7 +314,7 @@
             // get any response at all from the new location.
             validate: (response) => response instanceof Response,
             interval: 3000,
-            maxConsecutiveNetworkErrors: 40,
+            maxConsecutiveNetworkErrors: 60,
           }).then(() => {
             window.location = futureLocation;
           }).catch((error) => {

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -250,8 +250,8 @@
         }
 
         async initialize() {
-          this.state = "initializing";
           this.inputError = null;
+          this.state = "initializing";
           controllers.determineHostname()
             .then((hostname) => {
               this.initialHostname = hostname;
@@ -288,8 +288,8 @@
                 // Display validation errors inline in order to make it more
                 // convenient for the user to correct them.
                 // TODO(jotaen): Rely on the HTTP status code once we have that
-                this.state = "prompt";
                 this.inputError = error.toString();
+                this.state = "prompt";
                 return;
               }
               this.show = false;

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -269,7 +269,6 @@
         }
 
         doChangeHostname() {
-          this.state = "changing";
           controllers.changeHostname(this.elements.hostnameInput.value)
             .then((newHostname) => {
               return controllers.shutdown(/*restart=*/ true)
@@ -283,6 +282,7 @@
             }).then((redirectURL) => {
               this.elements.futureLocation.innerText = redirectURL;
               this.elements.futureLocation.href = redirectURL;
+              this.state = "changing";
               return this.waitForReboot(redirectURL);
             }).catch((error) => {
               if (error.toString().toLowerCase().includes("invalid input")) {
@@ -305,12 +305,14 @@
           // Try to reach the future location for a total of 120 seconds.
           // Note: it’s not enough to just wait for the mere reboot, but it
           // might require additional time for the new hostname to propagate.
-          poll({
+          return poll({
             fn: () => fetch(futureLocation, {
-                // Disable CORS as we only send a “ping” here
+                // Disable CORS as we only send a “ping” here.
                 mode: "no-cors",
-              }).then((response) => response.status),
-            validate: (status) => status === 200,
+              }),
+            // Due to `no-cors` the only thing we can check for is whether we
+            // get any response at all from the new location.
+            validate: (response) => response instanceof Response,
             interval: 3000,
             maxConsecutiveNetworkErrors: 40,
           }).then(() => {

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -306,27 +306,16 @@
           // - The timeout behaviour of `fetch` is browser-dependent.
           // - It’s not possible to tell exactly when the new hostname will
           //   actually be reachable, because of DNS propagation and caching.
-          // - We are issuing the “pings” from the old location but the server
-          //   doesn’t allow requests from other locations due to CORS, so the
-          //   new server would reject our pings. Therefore we have to use
-          //   `no-cors`. That implies that the response is opaque, though, so
-          //   we can only tell that there is a response but we cannot inspect
-          //   it any further. (`response.status` is `0`, for example.)
+          // - The `status` endpoint is the only one that allows requests
+          //   from everywhere (due to CORS), so it’s safe to request from
+          //   the “old” location.
           return poll({
-            fn: () => fetch(futureLocation, {
-                mode: "no-cors",
-              }),
-            validate: (response) => response instanceof Response,
+            fn: () => controllers.checkStatus(futureLocation),
+            validate: (isUpAndRunning) => isUpAndRunning === true,
             interval: 3000,
             maxConsecutiveNetworkErrors: 60,
           }).then(() => {
-            setTimeout(() => {
-              // The response status might be 502 shortly after reboot, but we
-              // cannot tell for sure due to the CORS behaviour described
-              // above. Therefore we just delay the redirect by a bit and hope
-              // for the best.
-              window.location = futureLocation;
-            }, 3000);
+            window.location = futureLocation;
           }).catch((error) => {
             console.error(error);
             this.show = false;

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -252,66 +252,68 @@
         async initialize() {
           this.state = "initializing";
           this.inputError = null;
-          try {
-            const hostname = await controllers.determineHostname();
-            this.initialHostname = hostname;
-            this.elements.hostnameInput.value = hostname;
-            this.onInputChanged(hostname);
-            this.state = "prompt";
-          } catch(error) {
-            this.show = false;
-            this.emitChangeHostnameFailureEvent(
-              "Failed to determine hostname",
-              error
-            );
-          }
+          controllers.determineHostname()
+            .then((hostname) => {
+              this.initialHostname = hostname;
+              this.elements.hostnameInput.value = hostname;
+              this.onInputChanged(hostname);
+              this.state = "prompt";
+            }).catch((error) => {
+              this.show = false;
+              this.emitChangeHostnameFailureEvent(
+                "Failed to determine hostname",
+                error
+              );
+            });
         }
 
         async doChangeHostname() {
           this.state = "changing";
-          try {
-            const newHostname = await controllers
-              .changeHostname(this.elements.hostnameInput.value);
-            await controllers.shutdown(/*restart=*/ true);
-            const redirectURL = futureLocation(
-              window.location,
-              this.initialHostname,
-              newHostname,
-            );
-            this.elements.futureLocation.innerText = redirectURL;
-            this.elements.futureLocation.href = redirectURL;
-            return await this.waitForReboot(redirectURL);
-          } catch(error) {
-            if (error.toString().toLowerCase().includes("invalid input")) {
-              // Display validation errors inline in order to make it more
-              // convenient for the user to correct them.
-              // TODO(jotaen): Rely on the HTTP status code once we have that
-              this.state = "prompt";
-              this.inputError = error.toString();
-              return;
-            }
-            this.show = false;
-            this.emitChangeHostnameFailureEvent(
-              "Failed to change hostname",
-              error
-            );
-          }
+          controllers.changeHostname(this.elements.hostnameInput.value)
+            .then((newHostname) => {
+              return newHostname;
+              return controllers.shutdown(/*restart=*/ true)
+                .then(() => newHostname);
+            }).then((newHostname) => {
+              return futureLocation(
+                window.location,
+                this.initialHostname,
+                newHostname,
+              );
+            }).then((redirectURL) => {
+              this.elements.futureLocation.innerText = redirectURL;
+              this.elements.futureLocation.href = redirectURL;
+              return this.waitForReboot(redirectURL);
+            }).catch((error) => {
+              if (error.toString().toLowerCase().includes("invalid input")) {
+                // Display validation errors inline in order to make it more
+                // convenient for the user to correct them.
+                // TODO(jotaen): Rely on the HTTP status code once we have that
+                this.state = "prompt";
+                this.inputError = error.toString();
+                return;
+              }
+              this.show = false;
+              this.emitChangeHostnameFailureEvent(
+                "Failed to change hostname",
+                error
+              );
+            });
         }
 
         async waitForReboot(futureLocation) {
-          try {
-            // Try to reach the future location for a total of 60 seconds.
-            await poll({
-              fn: async () => {
-                const response = await fetch(futureLocation);
-                return response.status;
-              },
-              validate: (status) => status === 200,
-              interval: 3000,
-              maxConsecutiveNetworkErrors: 20,
-            });
+          // Try to reach the future location for a total of 60 seconds.
+          poll({
+            fn: async () => {
+              const response = await fetch(futureLocation);
+              return response.status;
+            },
+            validate: (status) => status === 200,
+            interval: 3000,
+            maxConsecutiveNetworkErrors: 20,
+          }).then(() => {
             window.location = futureLocation;
-          } catch(error) {
+          }).catch((error) => {
             console.error(error);
             this.show = false;
             this.emitChangeHostnameFailureEvent(
@@ -320,7 +322,7 @@
               " have failed to reboot, or your browser is failing to " +
               " resolve the new hostname."
             );
-          }
+          });
         }
 
         emitChangeHostnameFailureEvent(summary, detail) {

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -179,7 +179,7 @@
 
           this.elements.hostnameInput
             .addEventListener("keydown", evt => {
-              // Prevent keystrokes from being send to TinyPilot
+              // Prevent keystrokes from being sent to TinyPilot
               evt.stopPropagation();
             })
           this.elements.hostnameInput

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -135,8 +135,7 @@
      * @returns {string}
      */
     function futureLocation(currentLocation, oldHostname, newHostname) {
-      const protocol = currentLocation.protocol
-      const port = currentLocation.port;
+      const protocol = currentLocation.protocol + "//";
       let fqdn = currentLocation.hostname;
       if (fqdn.startsWith(oldHostname + ".")) {
         // When the fqdn (fully qualified domain name) starts with the old
@@ -149,7 +148,9 @@
         // one. That might not be correct, but it’s the best possible guess.
         fqdn = newHostname;
       }
-      return `${protocol}//${fqdn}:${port}`;
+      const port = currentLocation.port === "" ?
+        "" : `:${currentLocation.port}`;
+      return protocol + fqdn + port;
     }
 
     customElements.define(
@@ -305,13 +306,10 @@
           // Note: it’s not enough to just wait for the mere reboot, but it
           // might require additional time for the new hostname to propagate.
           poll({
-            fn: async () => {
-              const response = await fetch(futureLocation, {
+            fn: () => fetch(futureLocation, {
                 // Disable CORS as we only send a “ping” here
                 mode: "no-cors",
-              });
-              return response.status;
-            },
+              }).then((response) => response.status),
             validate: (status) => status === 200,
             interval: 3000,
             maxConsecutiveNetworkErrors: 40,

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -254,10 +254,10 @@
           this.inputError = null;
           try {
             const hostname = await controllers.determineHostname();
-            this.state = "prompt";
             this.initialHostname = hostname;
             this.elements.hostnameInput.value = hostname;
             this.onInputChanged(hostname);
+            this.state = "prompt";
           } catch(error) {
             this.show = false;
             this.emitChangeHostnameFailureEvent(

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -302,7 +302,7 @@
         }
 
         async waitForReboot(futureLocation) {
-          // Try to reach the future location for a total of 60 seconds.
+          // Try to reach the future location for a total of 120 seconds.
           poll({
             fn: async () => {
               const response = await fetch(futureLocation);
@@ -310,7 +310,7 @@
             },
             validate: (status) => status === 200,
             interval: 3000,
-            maxConsecutiveNetworkErrors: 20,
+            maxConsecutiveNetworkErrors: 40,
           }).then(() => {
             window.location = futureLocation;
           }).catch((error) => {

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -271,7 +271,6 @@
           this.state = "changing";
           controllers.changeHostname(this.elements.hostnameInput.value)
             .then((newHostname) => {
-              return newHostname;
               return controllers.shutdown(/*restart=*/ true)
                 .then(() => newHostname);
             }).then((newHostname) => {

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -304,12 +304,14 @@
         waitForReboot(futureLocation) {
           // Try to reach the future location. Note:
           // - The timeout behaviour of `fetch` is browser-dependent.
-          // - How long it takes exactly for the new hostname to be reachable
-          //   is dependent on DNS propagation and caching.
-          // - We are still issuing the “ping” requests from the old location
-          //   and the server doesn’t have any CORS policy, so we have to use
-          //   `no-cors`. That entails that the response is opaque, so its
-          //   status will be `0` for example.
+          // - It’s not possible to tell exactly when the new hostname will
+          //   actually be reachable, because of DNS propagation and caching.
+          // - We are issuing the “pings” from the old location but the server
+          //   doesn’t allow requests from other locations due to CORS, so the
+          //   new server would reject our pings. Therefore we have to use
+          //   `no-cors`. That implies that the response is opaque, though, so
+          //   we can only tell that there is a response but we cannot inspect
+          //   it any further. (`response.status` is `0`, for example.)
           return poll({
             fn: () => fetch(futureLocation, {
                 mode: "no-cors",

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -302,21 +302,29 @@
         }
 
         waitForReboot(futureLocation) {
-          // Try to reach the future location for a total of 180 seconds.
-          // Note: it’s not enough to just wait for the mere reboot, but it
-          // might require additional time for the new hostname to propagate.
+          // Try to reach the future location. Note:
+          // - The timeout behaviour of `fetch` is browser-dependent.
+          // - How long it takes exactly for the new hostname to be reachable
+          //   is dependent on DNS propagation and caching.
+          // - We are still issuing the “ping” requests from the old location
+          //   and the server doesn’t have any CORS policy, so we have to use
+          //   `no-cors`. That entails that the response is opaque, so its
+          //   status will be `0` for example.
           return poll({
             fn: () => fetch(futureLocation, {
-                // Disable CORS as we only send a “ping” here.
                 mode: "no-cors",
               }),
-            // Due to `no-cors` the only thing we can check for is whether we
-            // get any response at all from the new location.
             validate: (response) => response instanceof Response,
             interval: 3000,
             maxConsecutiveNetworkErrors: 60,
           }).then(() => {
-            window.location = futureLocation;
+            setTimeout(() => {
+              // The response status might be 502 shortly after reboot, but we
+              // cannot tell for sure due to the CORS behaviour described
+              // above. Therefore we just delay the redirect by a bit and hope
+              // for the best.
+              window.location = futureLocation;
+            }, 3000);
           }).catch((error) => {
             console.error(error);
             this.show = false;

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -316,9 +316,9 @@
             this.show = false;
             this.emitChangeHostnameFailureEvent(
               "Failed to redirect",
-              "Cannot reach TinyPilot under the new hostname. Reasons might" +
-              " be that it failed to reboot, or that the new hostname" +
-              " cannot be resolved."
+              "Cannot reach TinyPilot under the new hostname. The device may" +
+              " have failed to reboot, or your browser is failing to " +
+              " resolve the new hostname."
             );
           }
         }

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -1,0 +1,342 @@
+<template id="change-hostname-template">
+  <style>
+    @import "css/button.css";
+
+    .overlay {
+      display: none;
+      -webkit-touch-callout: none;
+      -webkit-user-select: none;
+      -khtml-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
+    }
+
+    :host([show="true"]) .overlay {
+      display: block;
+      position: fixed;
+      width: 100%;
+      height: 100%;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background-color: rgba(0, 0, 0, 0.8);
+      z-index: 2;
+    }
+
+    #initializing,
+    #prompt,
+    #changing,
+    #input-error {
+      display: none;
+    }
+
+    :host([state="initializing"]) #initializing {
+      display: block;
+    }
+
+    :host([state="prompt"]) #prompt {
+      display: block;
+    }
+
+    :host([state="changing"]) #changing {
+      display: block;
+    }
+
+    :host([has-input-error="true"]) #input-error {
+      display: block;
+    }
+
+    #change-hostname-panel > div {
+      background-color: rgb(252, 236, 223);
+      border: 1px solid rgb(139, 97, 62);
+      max-width: 800px;
+      margin: 100px auto 0rem auto;
+      padding: 2rem;
+    }
+
+    #hostname-input {
+      margin: 0 auto;
+      font-family: monospace;
+      font-size: 1.1rem;
+      padding: 0.3rem;
+    }
+
+    #change-and-restart {
+      background-color: rgb(15, 157, 88);
+    }
+
+    #change-and-restart:disabled {
+      background-color: rgb(117, 202, 161);
+      cursor: not-allowed;
+    }
+
+    #change-and-restart:hover {
+      background-color: rgb(65, 177, 108);
+    }
+
+    .input-container {
+      margin: 1.5rem 0;
+    }
+
+    #input-error {
+      color: rgb(153, 8, 8);
+      font-weight: bold;
+    }
+  </style>
+  <div id="change-hostname-panel" class="overlay">
+    <div id="initializing">
+      <p>Retrieving current hostname</p>
+      <progress-spinner></progress-spinner>
+      <button id="cancel-initialization" type="button">Cancel</button>
+    </div>
+    <div id="prompt">
+      <h3>Change hostname</h3>
+      <p>
+        Change the hostname of your TinyPilot device. TinyPilot will be
+        automatically restarted afterwards in order to apply the change.
+        Note that this does not change the hostname of the machine to which
+        TinyPilot is attached.
+      </p>
+      <div class="input-container">
+        <label for="hostname-input">Hostname:</label>
+        <input type="text" id="hostname-input" size="30">
+        <p id="input-error"><!-- Filled programmatically --></p>
+      </div>
+      <button id="change-and-restart" type="button">
+        Change and restart
+      </button>
+      <button id="cancel-hostname-change" type="button">Cancel</button>
+    </div>
+    <div id="changing">
+      <h3>Changing hostname</h3>
+      <p>
+        Waiting for TinyPilot to reboot at
+        <a href="" id="future-location"><!-- Filled programmatically --></a>
+        <br>
+        You will be redirected automatically.
+      </p>
+      <progress-spinner></progress-spinner>
+    </div>
+  </div>
+</template>
+
+<script src="/js/util/poll.js"></script>
+<script>
+  (function () {
+    const doc = (document._currentScript || document.currentScript)
+      .ownerDocument;
+    const template = doc.querySelector("#change-hostname-template");
+
+    /**
+     * Figure out the new URL under which TinyPilot will become
+     * available after rebooting.
+     * @param {Location} currentLocation
+     * @param {string} oldHostname
+     * @param {string} newHostname
+     * @returns {string}
+     */
+    function futureLocation(currentLocation, oldHostname, newHostname) {
+      const protocol = currentLocation.protocol
+      const port = currentLocation.port;
+      let fqdn = currentLocation.hostname;
+      if (fqdn.startsWith(oldHostname + ".")) {
+        // When the fqdn (fully qualified domain name) starts with the old
+        // hostname followed by a dot, then we replace the old one by the
+        // new one in order to preserve the domain part.
+        // E.g.: "oldtinypilot.home.local" => "newtinypilot.home.local"
+        fqdn = fqdn.replace(oldHostname, newHostname);
+      } else {
+        // Otherwise we just assume the new hostname to be a fully qualified
+        // one. That might not be correct, but it’s the best possible guess.
+        fqdn = newHostname;
+      }
+      return `${protocol}//${fqdn}:${port}`;
+    }
+
+    customElements.define(
+      "change-hostname-dialog",
+      class extends HTMLElement {
+        constructor() {
+          super();
+        }
+
+        connectedCallback() {
+          this.attachShadow({ mode: "open" });
+          this.shadowRoot.appendChild(template.content.cloneNode(true));
+          this.elements = {
+            inputError: this.shadowRoot
+              .getElementById("input-error"),
+            hostnameInput: this.shadowRoot
+              .getElementById("hostname-input"),
+            changeAndRestart: this.shadowRoot
+              .getElementById("change-and-restart"),
+            cancelInitialization: this.shadowRoot
+              .getElementById("cancel-initialization"),
+            cancelHostnameChange: this.shadowRoot
+              .getElementById("cancel-hostname-change"),
+            futureLocation: this.shadowRoot
+              .getElementById("future-location"),
+          };
+
+          this.elements.hostnameInput
+            .addEventListener("keydown", evt => {
+              // Prevent keystrokes from being send to TinyPilot
+              evt.stopPropagation();
+            })
+          this.elements.hostnameInput
+            .addEventListener("input", () => {
+              this.onInputChanged();
+            })
+          this.elements.changeAndRestart
+            .addEventListener("click", () => {
+              this.doChangeHostname();
+            });
+          this.elements.cancelInitialization
+            .addEventListener("click", () => {
+              this.show = false;
+            });
+          this.elements.cancelHostnameChange
+            .addEventListener("click", () => {
+              this.show = false;
+            });
+        }
+
+        get show() {
+          return this.getAttribute("show") === "true";
+        }
+
+        set show(newValue) {
+          if (this.show !== newValue && newValue === true) {
+            // Initialize when opening freshly
+            this.initialize();
+          }
+          this.setAttribute("show", newValue);
+        }
+
+        get state() {
+          return this.getAttribute("state");
+        }
+
+        set state(newValue) {
+          this.setAttribute("state", newValue);
+        }
+
+        get initialHostname() {
+          return this.getAttribute("initial-hostname");
+        }
+
+        set initialHostname(initialHostname) {
+          this.setAttribute("initial-hostname", initialHostname);
+        }
+
+        get inputError() {
+          return this.getAttribute("has-input-error");
+        }
+
+        set inputError(message) {
+          const inputError = this.elements.inputError;
+          if (message) {
+            this.setAttribute("has-input-error", "true");
+            inputError.innerText = message;
+            return;
+          }
+          this.removeAttribute("has-input-error");
+          inputError.innerText = "";
+        }
+
+        onInputChanged() {
+          const isEqualToInitialValue =
+            (this.elements.hostnameInput.value === this.initialHostname);
+          this.elements.changeAndRestart.disabled = isEqualToInitialValue;
+        }
+
+        async initialize() {
+          this.state = "initializing";
+          this.inputError = null;
+          try {
+            const hostname = await controllers.determineHostname();
+            this.state = "prompt";
+            this.initialHostname = hostname;
+            this.elements.hostnameInput.value = hostname;
+            this.onInputChanged(hostname);
+          } catch(error) {
+            this.show = false;
+            this.emitChangeHostnameFailureEvent(
+              "Failed to determine hostname",
+              error
+            );
+          }
+        }
+
+        async doChangeHostname() {
+          this.state = "changing";
+          try {
+            const newHostname = await controllers
+              .changeHostname(this.elements.hostnameInput.value);
+            await controllers.shutdown(/*restart=*/ true);
+            const redirectURL = futureLocation(
+              window.location,
+              this.initialHostname,
+              newHostname,
+            );
+            this.elements.futureLocation.innerText = redirectURL;
+            this.elements.futureLocation.href = redirectURL;
+            return await this.waitForReboot(redirectURL);
+          } catch(error) {
+            if (error.toString().toLowerCase().includes("invalid input")) {
+              // Display validation errors inline in order to make it more
+              // convenient for the user to correct them.
+              // TODO(jotaen): Rely on the HTTP status code once we have that
+              this.state = "prompt";
+              this.inputError = error.toString();
+              return;
+            }
+            this.show = false;
+            this.emitChangeHostnameFailureEvent(
+              "Failed to change hostname",
+              error
+            );
+          }
+        }
+
+        async waitForReboot(futureLocation) {
+          try {
+            // Try to reach the future location for a total of 60 seconds.
+            await poll({
+              fn: async () => {
+                const response = await fetch(futureLocation);
+                return response.status;
+              },
+              validate: (status) => status === 200,
+              interval: 3000,
+              maxConsecutiveNetworkErrors: 20,
+            });
+            window.location = futureLocation;
+          } catch(error) {
+            console.error(error);
+            this.show = false;
+            this.emitChangeHostnameFailureEvent(
+              "Failed to redirect",
+              "Cannot reach TinyPilot under the new hostname. Reasons might" +
+              " be that it failed to reboot, or that the new hostname" +
+              " cannot be resolved."
+            );
+          }
+        }
+
+        emitChangeHostnameFailureEvent(summary, detail) {
+          this.dispatchEvent(
+            new CustomEvent("change-hostname-failure", {
+              detail: { summary, detail },
+              bubbles: true,
+              composed: true,
+            })
+          );
+        }
+
+      }
+    );
+  })();
+</script>

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -94,10 +94,7 @@
     <div id="prompt">
       <h3>Change hostname</h3>
       <p>
-        Change the hostname of your TinyPilot device. TinyPilot will be
-        automatically restarted afterwards in order to apply the change.
-        Note that this does not change the hostname of the machine to which
-        TinyPilot is attached.
+        Enter a new hostname for TinyPilot.
       </p>
       <div class="input-container">
         <label for="hostname-input">Hostname:</label>

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -249,7 +249,7 @@
           this.elements.changeAndRestart.disabled = isEqualToInitialValue;
         }
 
-        async initialize() {
+        initialize() {
           this.inputError = null;
           this.state = "initializing";
           controllers.determineHostname()
@@ -267,7 +267,7 @@
             });
         }
 
-        async doChangeHostname() {
+        doChangeHostname() {
           this.state = "changing";
           controllers.changeHostname(this.elements.hostnameInput.value)
             .then((newHostname) => {
@@ -300,8 +300,10 @@
             });
         }
 
-        async waitForReboot(futureLocation) {
+        waitForReboot(futureLocation) {
           // Try to reach the future location for a total of 120 seconds.
+          // Note: it’s not enough to just wait for the mere reboot, but it
+          // might require additional time for the new hostname to propagate.
           poll({
             fn: async () => {
               const response = await fetch(futureLocation);

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -33,6 +33,7 @@
 
         <shutdown-dialog id="shutdown-dialog"></shutdown-dialog>
         <update-dialog id="update-dialog"></update-dialog>
+        <change-hostname-dialog id="change-hostname-dialog"></change-hostname-dialog>
 
         <remote-screen
           id="remote-screen"


### PR DESCRIPTION
This PR is the third and last part of the [feature to change TinyPilot’s hostname via the web UI](https://github.com/mtlynch/tinypilot/issues/433) and adds the frontend pieces.

![2021-02-18 20-31-50 2021-02-18 20_33_35](https://user-images.githubusercontent.com/3618384/108411155-9771ad80-7228-11eb-8336-f6bd1e1c985c.gif)

~The PR should be feature-complete, but it’s nevertheless tentative because I want to look at it again with a fresh pair of eyes. There are a couple of things to discuss, though, so I was hoping that you (@mtlynch) could take a first look already and give me some feedback.~

~I also am unable to do any “real-life” acceptance testing currently, because I don’t have a Pi setup for development yet, which makes me feel a bit uncomfortable…~ *(I got around to doing some testing “for real” now, see comment below.)*

## Remarks

### Wording/text in the dialog box
I’m not sure what level of knowledge to expect from the end user, so the wording in the popup might have to be revised. Here are some thoughts around that:
- It might be opaque what “changing the hostname” really does. We are effectively populating a new hostname to TinyPilot, but whether TinyPilot can afterwards be reached under that new hostname in the network is a different story. So there are a few error cases that are outside of our control. Maybe this can be communicated in a more transparent manner? Or maybe that’s not necessary?
- I debated to show the rules for valid hostnames in the initial text of the dialog. I lean towards not doing that in order to keep the description text focused. In case someone runs into this there is still the error message, which should be pretty helpful.

### Error handling
I thought that it’s good to distinguish between operation failures and input validation errors. For the former I used the existing pattern of error panels, for the latter I displayed them inline in the dialog box in order to make it more convenient for the user to correct their input. [Having proper HTTP response codes](https://github.com/mtlynch/tinypilot/issues/506) would make that distinction more robust (implementation-wise), for now I don’t see any other way than to rely on the text structure.

~Note that I slightly adjusted the backened error message, to make it sound a bit less technical – the user doesn’t care about some *HTTP request* being malformed after all, but only about the actual value.~
~Also, I had forgotten about the `localhost` case, which I added to the validator as well.~ *(Done through separate PRs.)*

### URL redirection
I hope my approach to figure out the new URL makes sense, i.e. is sufficient and that I have considered everything. (See `futureLocation()` in `change-hostname-dialog.html`). I also am a bit on the fence about not having tests for that method. Shall I setup unit tests for the frontend as part of this PR?

## Miscellaneous
- ~I pulled out the `poll` function in order to reuse it. In that process I also applied a small bug fix: if you use [`String.indexOf`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/indexOf) in JS, always make sure to check it against `-1`. If the search term appears at the beginning of the string (like in this case with `NetworkError`) then `indexOf` returns `0` which evaluates to `false`. So either do `error.message.indexOf("NetworkError") !== -1` or – better – `error.message.includes("NetworkError")`, which I have corrected it to.~ *(Done through separate PR.)*
- I added the same CSS code around `.overlay` for the third time now. I thought that refactoring this is out of scope for this PR, but it might be worthwhile to consider extracting an `<overlay>` component.
- I found both Promise paradigms `async/await` and `then()/catch()`. I wasn’t sure which one you prefer, so I used `then()/catch()` in `controller.js` for consistency, and `async/await` in `change-hostname-dialog.html`, because I found that used in `update-dialog.html` more often. The Google style guide doesn’t seem to have an explicit opinion, although they only use `then()/catch()` in their examples. I don’t mind either way.
- Is it deliberate to gitignore `lib/` (et al) in the entire project as opposed to only in the project root (i.e. `/lib/`)? When I extracted the `poll` JS function I had put it in `js/lib/poll.js` initially, but then almost failed to notice that it wouldn’t show up in git.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mtlynch/tinypilot/521)
<!-- Reviewable:end -->
