### PR TITLE
Fix detection of network errors during polling

### DIFF
--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -132,7 +132,7 @@
           consecutiveNetworkErrors = 0;
         } catch (error) {
           result = null;
-          if (error.message.indexOf("NetworkError")) {
+          if (error.message.includes("NetworkError")) {
             consecutiveNetworkErrors++;
             if (
               maxConsecutiveNetworkErrors &&


### PR DESCRIPTION
Tiny fix in the polling mechanism of the update dialog: when using [`String.prototype.indexOf`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/indexOf) in JavaScript to find a substring, the result should always be compared against `-1` to check for absence. If the search term appears at the beginning of the string (like in this case with “NetworkError”) then `indexOf` returns `0` which evaluates to `false`.

Either one can do `error.message.indexOf("NetworkError") !== -1` or – better, since more expressive – `error.message.includes("NetworkError")`, which I have changed it to here.