### PR TITLE
Fix hostname validation in backend: reject `localhost` as value

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -208,7 +208,7 @@ def hostname_set():
         hostname.change(new_hostname)
         return _json_success()
     except request_parsers.errors.Error as e:
-        return _json_error('Malformed request: %s' % str(e)), 200
+        return _json_error('Invalid input: %s' % str(e)), 200
     except hostname.Error as e:
         return _json_error('Operation failed: %s' % str(e)), 200
 

--- a/app/request_parsers/hostname.py
+++ b/app/request_parsers/hostname.py
@@ -9,5 +9,6 @@ def parse_hostname(request):
     if not hostname_validator.validate(hostname):
         raise errors.InvalidHostnameError(
             'Hostnames can only contain the letters a-z, digits and dashes'
-            ' (it cannot start with a dash, though).')
+            ' (it cannot start with a dash, though). It must contain 1-63'
+            ' characters and cannot be "localhost".')
     return hostname

--- a/app/request_parsers/validators/hostname.py
+++ b/app/request_parsers/validators/hostname.py
@@ -16,6 +16,8 @@ def validate(hostname):
     """
     if not isinstance(hostname, str):
         return False
+    if hostname == 'localhost':
+        return False
     if hostname.startswith('-'):
         return False
     if _HOSTNAME_PATTERN.match(hostname) is None:

--- a/app/request_parsers/validators/hostname_test.py
+++ b/app/request_parsers/validators/hostname_test.py
@@ -20,6 +20,9 @@ class HostnameValidationTest(unittest.TestCase):
         self.assertFalse(hostname.validate('tinypilot***'))
         self.assertFalse(hostname.validate('tiny.pilot'))
 
+    def test_rejects_localhost_as_hostname(self):
+        self.assertFalse(hostname.validate('localhost'))
+
     def test_rejects_empty_hostname(self):
         self.assertFalse(hostname.validate(''))
 


### PR DESCRIPTION
[PR #433](https://github.com/mtlynch/tinypilot/issues/433) had introduced the backend endpoints for changing the device hostname. It didn’t implement the rule, however, that the hostname must not be `localhost`. This is fixed here.

Also, the wording of the “bad request” error message was slightly adjusted to make it sound a bit less techncical. The message is intended to be displayed as is [in the frontend](https://github.com/mtlynch/tinypilot/pull/521).