### PR TITLE
Frontend: Extract polling utility in order to be able to reuse it

### DIFF
--- a/app/static/js/util/poll.js
+++ b/app/static/js/util/poll.js
@@ -1,0 +1,42 @@
+/**
+ * Calls a function repetitively until either the result is valid or the
+ * maximum number of network errors is reached.
+ *
+ * @template T
+ * @param {function(): Promise<T>} fn The function to be polled.
+ * @param {function(T): boolean} validate Function to validate fn’s result.
+ * @param {number} interval Interval in milliseconds.
+ * @param {number} maxConsecutiveNetworkErrors The maximum number of network
+ *     errors after which the polling should stop.
+ * @returns {Promise<T>}
+ */
+async function poll({ fn, validate, interval, maxConsecutiveNetworkErrors }) {
+  let result = null;
+  let consecutiveNetworkErrors = 0;
+
+  const executePoll = async (resolve, reject) => {
+    try {
+      result = await fn();
+      consecutiveNetworkErrors = 0;
+    } catch (error) {
+      result = null;
+      if (error.message.includes("NetworkError")) {
+        consecutiveNetworkErrors++;
+        if (
+          maxConsecutiveNetworkErrors &&
+          consecutiveNetworkErrors === maxConsecutiveNetworkErrors
+        ) {
+          return reject(error);
+        }
+      }
+    }
+
+    if (validate(result)) {
+      return resolve(result);
+    } else {
+      setTimeout(executePoll, interval, resolve, reject);
+    }
+  };
+
+  return new Promise(executePoll);
+}

--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -115,44 +115,9 @@
   </div>
 </template>
 
+<script src="/js/util/poll.js"></script>
 <script>
   (function () {
-    const poll = async ({
-      fn,
-      validate,
-      interval,
-      maxConsecutiveNetworkErrors,
-    }) => {
-      let result = null;
-      let consecutiveNetworkErrors = 0;
-
-      const executePoll = async (resolve, reject) => {
-        try {
-          result = await fn();
-          consecutiveNetworkErrors = 0;
-        } catch (error) {
-          result = null;
-          if (error.message.includes("NetworkError")) {
-            consecutiveNetworkErrors++;
-            if (
-              maxConsecutiveNetworkErrors &&
-              consecutiveNetworkErrors === maxConsecutiveNetworkErrors
-            ) {
-              return reject(error);
-            }
-          }
-        }
-
-        if (validate(result)) {
-          return resolve(result);
-        } else {
-          setTimeout(executePoll, interval, resolve, reject);
-        }
-      };
-
-      return new Promise(executePoll);
-    };
-
     const doc = (document._currentScript || document.currentScript)
       .ownerDocument;
     const template = doc.querySelector("#update-dialog-template");


### PR DESCRIPTION
`update-dialog.html` currently contains a `poll` function that “watches” a Promise until it resolves to a desired result. I’d like to reuse this polling utility in https://github.com/mtlynch/tinypilot/pull/521, therefore it gets extracted in this PR here.

Apart from whitespace changes (and the JSdoc), the code relocation is verbatim.

I deliberately placed it inside a `util` folder, since I think it makes sense to separate domain-specific code from generic utilities.