### PR TITLE
Add sudo to the call to collect-debug-logs

### DIFF
--- a/app/debug_logs.py
+++ b/app/debug_logs.py
@@ -18,6 +18,6 @@ def collect():
     """
     try:
         return subprocess.check_output(
-            ['/opt/tinypilot-privileged/collect-debug-logs', '-q'])
+            ['sudo', '/opt/tinypilot-privileged/collect-debug-logs', '-q'])
     except subprocess.CalledProcessError as e:
         raise LogCollectionScriptFailedError(str(e)) from e


### PR DESCRIPTION
Otherwise, it executes as the tinypilot user which doesn't have permissions to access all logs.