### PR TITLE
Add sudo to the call to the `change-hostname` script

### DIFF
--- a/app/hostname.py
+++ b/app/hostname.py
@@ -43,7 +43,7 @@ def change(new_hostname):
     """
     try:
         return subprocess.check_output(
-            ['/opt/tinypilot-privileged/change-hostname', new_hostname],
+            ['sudo', '/opt/tinypilot-privileged/change-hostname', new_hostname],
             stderr=subprocess.STDOUT,
             universal_newlines=True)
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
Similarly to https://github.com/mtlynch/tinypilot/commit/778d3dadb86e641eb270d376716ffed58e6c3316 the `change-hostname` script also has to be executed through `sudo`, because it needs to write system files, which it needs root permission for.

(Screenshot from real TinyPilot device running on a Pi; in the dev environment it might not be apparent if you execute the server via a root user.)

<img width="942" alt="Screenshot 2021-02-23 at 13 30 42" src="https://user-images.githubusercontent.com/3618384/108843778-753aaf80-75db-11eb-86e8-d14f1a638d66.png">
