### PR TITLE
Make polling mechanism more reliable and more generic (frontend)

### DIFF
--- a/app/static/js/util/poll.js
+++ b/app/static/js/util/poll.js
@@ -18,7 +18,7 @@ async function poll({ fn, validate, interval, timeout }) {
       if (validate(result)) {
         return resolve(result);
       } else {
-        lastError = new Error("Result did not pass validation");
+        lastError = new Error("Operation timed out.");
       }
     } catch (error) {
       lastError = error;

--- a/app/static/js/util/poll.js
+++ b/app/static/js/util/poll.js
@@ -1,41 +1,33 @@
 /**
- * Calls a function repetitively until either the result is valid or the
- * maximum number of network errors is reached.
+ * Invokes a Promise repetitively until it resolves to the expected outcome.
  *
  * @template T
  * @param {function(): Promise<T>} fn The function to be polled.
  * @param {function(T): boolean} validate Function to validate fn’s result.
- * @param {number} interval Interval in milliseconds.
- * @param {number} maxConsecutiveNetworkErrors The maximum number of network
- *     errors after which the polling should stop.
+ * @param {number} interval Polling interval in milliseconds.
+ * @param {number} [timeout] Time in milliseconds after which to abort.
  * @returns {Promise<T>}
  */
-async function poll({ fn, validate, interval, maxConsecutiveNetworkErrors }) {
-  let result = null;
-  let consecutiveNetworkErrors = 0;
+async function poll({ fn, validate, interval, timeout }) {
+  const start = new Date().getTime();
+  let lastError = null;
 
   const executePoll = async (resolve, reject) => {
     try {
-      result = await fn();
-      consecutiveNetworkErrors = 0;
-    } catch (error) {
-      result = null;
-      if (error.message.includes("NetworkError")) {
-        consecutiveNetworkErrors++;
-        if (
-          maxConsecutiveNetworkErrors &&
-          consecutiveNetworkErrors === maxConsecutiveNetworkErrors
-        ) {
-          return reject(error);
-        }
+      const result = await fn();
+      if (validate(result)) {
+        return resolve(result);
+      } else {
+        lastError = new Error("Result did not pass validation");
       }
+    } catch (error) {
+      lastError = error;
     }
-
-    if (validate(result)) {
-      return resolve(result);
-    } else {
-      setTimeout(executePoll, interval, resolve, reject);
+    const totalTimeElapsed = new Date().getTime() - start;
+    if (timeout !== undefined && totalTimeElapsed > timeout) {
+      return reject(lastError);
     }
+    setTimeout(executePoll, interval, resolve, reject);
   };
 
   return new Promise(executePoll);

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -312,8 +312,8 @@
           return poll({
             fn: () => controllers.checkStatus(futureLocation),
             validate: (isUpAndRunning) => isUpAndRunning === true,
-            interval: 3000,
-            maxConsecutiveNetworkErrors: 60,
+            interval: 3 * 1000,
+            timeout: 180 * 1000,
           }).then(() => {
             window.location = futureLocation;
           }).catch((error) => {

--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -189,25 +189,14 @@
             });
         }
 
-        waitForUpdateToStart() {
-          return poll({
-            fn: controllers.getUpdateStatus,
-            validate: (status) => {
-              return ["IN_PROGRESS", "DONE"].includes(status);
-            },
-            interval: 1500,
-            maxConsecutiveNetworkErrors: 5,
-          });
-        }
-
         waitForUpdateToFinish() {
           return poll({
             fn: controllers.getUpdateStatus,
             validate: (status) => {
               return status === "DONE";
             },
-            interval: 1500,
-            maxConsecutiveNetworkErrors: 5,
+            interval: 2 * 1000,
+            timeout: 300 * 1000,
           });
         }
 
@@ -251,7 +240,6 @@
           }
 
           try {
-            await this.waitForUpdateToStart();
             await this.waitForUpdateToFinish();
             // Updating causes the backend to restart, changing the CSRF token.
             await controllers.refreshCsrfToken();

--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -245,10 +245,10 @@
             await controllers.refreshCsrfToken();
             await this.performRestart();
           } catch (error) {
-            console.error(error)
+            console.error(error);
             this.emitUpdateFailureEvent(
               "Failed to complete update",
-              "Please refresh this page and try again."
+              "Please refresh this page and try again. Error details: " + error
             );
             return;
           }

--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -245,7 +245,11 @@
             await controllers.refreshCsrfToken();
             await this.performRestart();
           } catch (error) {
-            this.emitUpdateFailureEvent("Failed to complete update", error);
+            console.error(error)
+            this.emitUpdateFailureEvent(
+              "Failed to complete update",
+              "Please refresh this page and try again."
+            );
             return;
           }
         }


### PR DESCRIPTION
This PR addresses / fixes https://github.com/mtlynch/tinypilot/issues/531. It’s not a direct fix, because in my opinion the polling mechanism should timeout *in general* and not just due to network errors. I think a user interface should never hang forever without giving indication that there might be a problem after a reasonable amount of time elapsed.

## Some remarks

- I simplified the logic in `update-dialog.html`. I hope that was not too much. Happy to change it back.
- I moved the `validate(result)` call into the `try` block. I know that you prefer to keep the `try` block slim, however, `null` could be a valid response (in theory) so if it’s outside the `try` we cannot distinguish this case without introducing additional helper variables.
- The error message in `update-dialog.html` could potentially be improved a bit. I think we shouldn’t show the technical error, because it’s most likely meaningless to the user. (Power users can still check the browser console to see it.)
- Unfortunately we don’t have something like `1_000` for integer literals in JS yet (at least not in the official spec), so I personally prefer to break bigger numbers up into a multiplication.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mtlynch/tinypilot/539)
<!-- Reviewable:end -->
