### PR TITLE
Fix formatting in templates

### DIFF
--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -98,7 +98,7 @@
       </p>
       <div class="input-container">
         <label for="hostname-input">Hostname:</label>
-        <input type="text" id="hostname-input" size="30">
+        <input type="text" id="hostname-input" size="30" />
         <p id="input-error"><!-- Filled programmatically --></p>
       </div>
       <button id="change-and-restart" type="button">
@@ -111,7 +111,7 @@
       <p>
         Waiting for TinyPilot to reboot at
         <a href="" id="future-location"><!-- Filled programmatically --></a>
-        <br>
+        <br />
         You will be redirected automatically.
       </p>
       <progress-spinner></progress-spinner>
@@ -148,8 +148,8 @@
         // one. That might not be correct, but it’s the best possible guess.
         fqdn = newHostname;
       }
-      const port = currentLocation.port === "" ?
-        "" : `:${currentLocation.port}`;
+      const port =
+        currentLocation.port === "" ? "" : `:${currentLocation.port}`;
       return protocol + fqdn + port;
     }
 
@@ -164,41 +164,36 @@
           this.attachShadow({ mode: "open" });
           this.shadowRoot.appendChild(template.content.cloneNode(true));
           this.elements = {
-            inputError: this.shadowRoot
-              .getElementById("input-error"),
-            hostnameInput: this.shadowRoot
-              .getElementById("hostname-input"),
-            changeAndRestart: this.shadowRoot
-              .getElementById("change-and-restart"),
-            cancelInitialization: this.shadowRoot
-              .getElementById("cancel-initialization"),
-            cancelHostnameChange: this.shadowRoot
-              .getElementById("cancel-hostname-change"),
-            futureLocation: this.shadowRoot
-              .getElementById("future-location"),
+            inputError: this.shadowRoot.getElementById("input-error"),
+            hostnameInput: this.shadowRoot.getElementById("hostname-input"),
+            changeAndRestart: this.shadowRoot.getElementById(
+              "change-and-restart"
+            ),
+            cancelInitialization: this.shadowRoot.getElementById(
+              "cancel-initialization"
+            ),
+            cancelHostnameChange: this.shadowRoot.getElementById(
+              "cancel-hostname-change"
+            ),
+            futureLocation: this.shadowRoot.getElementById("future-location"),
           };
 
-          this.elements.hostnameInput
-            .addEventListener("keydown", evt => {
-              // Prevent keystrokes from being sent to TinyPilot
-              evt.stopPropagation();
-            })
-          this.elements.hostnameInput
-            .addEventListener("input", () => {
-              this.onInputChanged();
-            })
-          this.elements.changeAndRestart
-            .addEventListener("click", () => {
-              this.doChangeHostname();
-            });
-          this.elements.cancelInitialization
-            .addEventListener("click", () => {
-              this.show = false;
-            });
-          this.elements.cancelHostnameChange
-            .addEventListener("click", () => {
-              this.show = false;
-            });
+          this.elements.hostnameInput.addEventListener("keydown", (evt) => {
+            // Prevent keystrokes from being sent to TinyPilot
+            evt.stopPropagation();
+          });
+          this.elements.hostnameInput.addEventListener("input", () => {
+            this.onInputChanged();
+          });
+          this.elements.changeAndRestart.addEventListener("click", () => {
+            this.doChangeHostname();
+          });
+          this.elements.cancelInitialization.addEventListener("click", () => {
+            this.show = false;
+          });
+          this.elements.cancelHostnameChange.addEventListener("click", () => {
+            this.show = false;
+          });
         }
 
         get show() {
@@ -246,20 +241,22 @@
 
         onInputChanged() {
           const isEqualToInitialValue =
-            (this.elements.hostnameInput.value === this.initialHostname);
+            this.elements.hostnameInput.value === this.initialHostname;
           this.elements.changeAndRestart.disabled = isEqualToInitialValue;
         }
 
         initialize() {
           this.inputError = null;
           this.state = "initializing";
-          controllers.determineHostname()
+          controllers
+            .determineHostname()
             .then((hostname) => {
               this.initialHostname = hostname;
               this.elements.hostnameInput.value = hostname;
               this.onInputChanged(hostname);
               this.state = "prompt";
-            }).catch((error) => {
+            })
+            .catch((error) => {
               this.show = false;
               this.emitChangeHostnameFailureEvent(
                 "Failed to determine hostname",
@@ -269,22 +266,27 @@
         }
 
         doChangeHostname() {
-          controllers.changeHostname(this.elements.hostnameInput.value)
+          controllers
+            .changeHostname(this.elements.hostnameInput.value)
             .then((newHostname) => {
-              return controllers.shutdown(/*restart=*/ true)
+              return controllers
+                .shutdown(/*restart=*/ true)
                 .then(() => newHostname);
-            }).then((newHostname) => {
+            })
+            .then((newHostname) => {
               return futureLocation(
                 window.location,
                 this.initialHostname,
-                newHostname,
+                newHostname
               );
-            }).then((redirectURL) => {
+            })
+            .then((redirectURL) => {
               this.elements.futureLocation.innerText = redirectURL;
               this.elements.futureLocation.href = redirectURL;
               this.state = "changing";
               return this.waitForReboot(redirectURL);
-            }).catch((error) => {
+            })
+            .catch((error) => {
               if (error.toString().toLowerCase().includes("invalid input")) {
                 // Display validation errors inline in order to make it more
                 // convenient for the user to correct them.
@@ -314,18 +316,20 @@
             validate: (isUpAndRunning) => isUpAndRunning === true,
             interval: 3 * 1000,
             timeout: 180 * 1000,
-          }).then(() => {
-            window.location = futureLocation;
-          }).catch((error) => {
-            console.error(error);
-            this.show = false;
-            this.emitChangeHostnameFailureEvent(
-              "Failed to redirect",
-              "Cannot reach TinyPilot under the new hostname. The device may" +
-              " have failed to reboot, or your browser is failing to " +
-              " resolve the new hostname."
-            );
-          });
+          })
+            .then(() => {
+              window.location = futureLocation;
+            })
+            .catch((error) => {
+              console.error(error);
+              this.show = false;
+              this.emitChangeHostnameFailureEvent(
+                "Failed to redirect",
+                "Cannot reach TinyPilot under the new hostname. The device may" +
+                  " have failed to reboot, or your browser is failing to " +
+                  " resolve the new hostname."
+              );
+            });
         }
 
         emitChangeHostnameFailureEvent(summary, detail) {
@@ -337,7 +341,6 @@
             })
           );
         }
-
       }
     );
   })();

--- a/app/templates/custom-elements/connection-indicator.html
+++ b/app/templates/custom-elements/connection-indicator.html
@@ -48,13 +48,11 @@
     <p>Connection</p>
     <content-tooltip position="bottom">
       <span class="status-dot"></span>
-      <p slot="text" class="connected-text"
-        >You are connected to TinyPilot.</span
-      >
+      <p slot="text" class="connected-text">You are connected to TinyPilot.</p>
       <p slot="text" class="disconnected-text">
         Could not connect to TinyPilot:
         <span id="disconnect-reason"></span>
-      </span>
+      </p>
     </content-tooltip>
   </div>
 </template>

--- a/app/templates/custom-elements/custom-footer.html
+++ b/app/templates/custom-elements/custom-footer.html
@@ -26,25 +26,26 @@
   (function () {
     const doc = (document._currentScript || document.currentScript)
       .ownerDocument;
-    const template = doc.querySelector('#custom-footer-template');
+    const template = doc.querySelector("#custom-footer-template");
     customElements.define(
-      'custom-footer',
+      "custom-footer",
       class CustomFooter extends HTMLElement {
         constructor() {
           super();
-          this.attachShadow({ mode: 'open' });
+          this.attachShadow({ mode: "open" });
         }
 
         connectedCallback() {
           this.shadowRoot.appendChild(template.content.cloneNode(true));
-          this.shadowRoot.querySelector('#debug-dialog-btn')
-            .addEventListener('click', () => {
-              const debugDialog = doc.querySelector('#debug-dialog');
+          this.shadowRoot
+            .querySelector("#debug-dialog-btn")
+            .addEventListener("click", () => {
+              const debugDialog = doc.querySelector("#debug-dialog");
               debugDialog.show = true;
               debugDialog.getLogs();
             });
         }
       }
-    )
+    );
   })();
 </script>

--- a/app/templates/custom-elements/debug-dialog.html
+++ b/app/templates/custom-elements/debug-dialog.html
@@ -53,7 +53,7 @@
 
     #logs-success .logs {
       font-family: consolas, monospace;
-      background-color: #F1F1F1;
+      background-color: #f1f1f1;
       user-select: text;
       text-align: left;
       overflow-y: scroll;
@@ -121,13 +121,13 @@
   (function () {
     const doc = (document._currentScript || document.currentScript)
       .ownerDocument;
-    const template = doc.querySelector('#debug-dialog-template');
+    const template = doc.querySelector("#debug-dialog-template");
     customElements.define(
-      'debug-dialog',
+      "debug-dialog",
       class DebugDialog extends HTMLElement {
         constructor() {
           super();
-          this.attachShadow({ mode: 'open' });
+          this.attachShadow({ mode: "open" });
           // Ensure that these methods always refer to the correct "this",
           // regardless of where they are called.
           this.close = this.close.bind(this);
@@ -139,48 +139,53 @@
 
         connectedCallback() {
           this.shadowRoot.appendChild(template.content.cloneNode(true));
-          this.shadowRoot.querySelectorAll('.close-btn').forEach((el) => {
-            el.addEventListener('click', this.close);
+          this.shadowRoot.querySelectorAll(".close-btn").forEach((el) => {
+            el.addEventListener("click", this.close);
           });
-          this.shadowRoot.querySelector('#logs-success .share-btn')
-            .addEventListener('click', this.getUrl);
-          this.shadowRoot.querySelector('#logs-success .copy-btn')
-            .addEventListener('click', (event) => {
+          this.shadowRoot
+            .querySelector("#logs-success .share-btn")
+            .addEventListener("click", this.getUrl);
+          this.shadowRoot
+            .querySelector("#logs-success .copy-btn")
+            .addEventListener("click", (event) => {
               this.onPushCopyButton(
                 /*buttonElement=*/ event.target,
-                /*sourceElement=*/ this.shadowRoot
-                  .querySelector('#logs-success .logs')
+                /*sourceElement=*/ this.shadowRoot.querySelector(
+                  "#logs-success .logs"
+                )
               );
             });
-          this.shadowRoot.querySelector('#url-success .copy-btn')
-            .addEventListener('click', (event) => {
+          this.shadowRoot
+            .querySelector("#url-success .copy-btn")
+            .addEventListener("click", (event) => {
               this.onPushCopyButton(
                 /*buttonElement=*/ event.target,
-                /*sourceElement=*/ this.shadowRoot
-                  .querySelector('#url-success .url')
+                /*sourceElement=*/ this.shadowRoot.querySelector(
+                  "#url-success .url"
+                )
               );
             });
-          doc.addEventListener('keydown', this._consumeKeystrokes);
+          doc.addEventListener("keydown", this._consumeKeystrokes);
         }
 
         disconnectedCallback() {
-          doc.removeEventListener('keydown', this._consumeKeystrokes);
+          doc.removeEventListener("keydown", this._consumeKeystrokes);
         }
 
         get show() {
-          return this.getAttribute('show') === 'true';
+          return this.getAttribute("show") === "true";
         }
 
         set show(newValue) {
-          this.setAttribute('show', newValue);
+          this.setAttribute("show", newValue);
         }
 
         get state() {
-          return this.getAttribute('state');
+          return this.getAttribute("state");
         }
 
         set state(newValue) {
-          this.setAttribute('state', newValue);
+          this.setAttribute("state", newValue);
         }
 
         _consumeKeystrokes(event) {
@@ -200,44 +205,50 @@
         }
 
         getLogs() {
-          this.state = 'logs-loading';
-          controllers.getDebugLogs()
-            .then(text => {
-              this.shadowRoot.querySelector('#logs-success .logs')
-                .textContent = text;
-              this.state = 'logs-success';
+          this.state = "logs-loading";
+          controllers
+            .getDebugLogs()
+            .then((text) => {
+              this.shadowRoot.querySelector(
+                "#logs-success .logs"
+              ).textContent = text;
+              this.state = "logs-success";
             })
-            .catch(error => {
-              this.shadowRoot.querySelector('#logs-fail .error')
-                .textContent = error;
-              this.state = 'logs-fail';
+            .catch((error) => {
+              this.shadowRoot.querySelector(
+                "#logs-fail .error"
+              ).textContent = error;
+              this.state = "logs-fail";
             });
         }
 
         getUrl() {
-          this.state = 'url-loading';
-          const text = this.shadowRoot.querySelector('#logs-success .logs')
+          this.state = "url-loading";
+          const text = this.shadowRoot.querySelector("#logs-success .logs")
             .textContent;
-          controllers.textToShareableUrl(text)
-            .then(url => {
-              const urlElement = this.shadowRoot
-                .querySelector('#url-success .url');
+          controllers
+            .textToShareableUrl(text)
+            .then((url) => {
+              const urlElement = this.shadowRoot.querySelector(
+                "#url-success .url"
+              );
               urlElement.textContent = url;
               urlElement.href = url;
-              this.state = 'url-success';
+              this.state = "url-success";
             })
-            .catch(error => {
-              this.shadowRoot.querySelector('#url-fail .error')
-                .textContent = error;
-              this.state = 'url-fail';
+            .catch((error) => {
+              this.shadowRoot.querySelector(
+                "#url-fail .error"
+              ).textContent = error;
+              this.state = "url-fail";
             });
         }
 
         onPushCopyButton(buttonElement, sourceElement) {
           copyElementTextToClipboard(sourceElement);
-          buttonElement.innerText = 'Copied!';
+          buttonElement.innerText = "Copied!";
         }
       }
-    )
+    );
   })();
 </script>

--- a/app/templates/custom-elements/menubar.html
+++ b/app/templates/custom-elements/menubar.html
@@ -184,8 +184,7 @@
     <li class="connection-indicator">
       <!-- The connection indicator will be moved
         to the status bar later on -->
-      <connection-indicator id="connection-indicator">
-      </connection-indicator>
+      <connection-indicator id="connection-indicator"> </connection-indicator>
     </li>
     <li class="nav-icon">
       <a href="https://github.com/mtlynch/tinypilot" target="_blank">
@@ -213,32 +212,47 @@
           this.attachShadow({ mode: "open" });
           this.shadowRoot.appendChild(template.content.cloneNode(true));
 
-          this.shadowRoot.getElementById("power-btn")
+          this.shadowRoot
+            .getElementById("power-btn")
             .addEventListener("click", () => {
               document.getElementById("shutdown-dialog").show = true;
-          });
-          this.shadowRoot.getElementById("screenshot-btn")
+            });
+          this.shadowRoot
+            .getElementById("screenshot-btn")
             .addEventListener("click", (evt) => {
-              evt.target.download = "TinyPilot-" + new Date().toISOString() + ".jpg";
-          });
-          this.shadowRoot.getElementById("fullscreen-btn")
+              evt.target.download =
+                "TinyPilot-" + new Date().toISOString() + ".jpg";
+            });
+          this.shadowRoot
+            .getElementById("fullscreen-btn")
             .addEventListener("click", (evt) => {
               document.getElementById("remote-screen").fullscreen = true;
               evt.preventDefault();
-          });
-          this.shadowRoot.getElementById("paste-btn")
+            });
+          this.shadowRoot
+            .getElementById("paste-btn")
             .addEventListener("click", () => {
               showPasteOverlay();
-          });
-          this.shadowRoot.getElementById("update-btn")
+            });
+          this.shadowRoot
+            .getElementById("update-btn")
             .addEventListener("click", () => {
               const updateDialog = document.getElementById("update-dialog");
               updateDialog.show = true;
               updateDialog.checkVersion();
-          });
-          this.shadowRoot.getElementById("change-hostname-btn").addEventListener("click", () => {
-            document.getElementById("change-hostname-dialog").show = true;
-          });
+            });
+          this.shadowRoot
+            .getElementById("change-hostname-btn")
+            .addEventListener("click", () => {
+              document.getElementById("change-hostname-dialog").show = true;
+            });
+          this.shadowRoot
+            .getElementById("debug-dialog-btn")
+            .addEventListener("click", () => {
+              const debugDialog = doc.querySelector("#debug-dialog");
+              debugDialog.show = true;
+              debugDialog.getLogs();
+            });
 
           // Add cursor options to navbar.
           const screenCursorOptions = [
@@ -272,7 +286,9 @@
         }
 
         set cursor(newCursor) {
-          for (const cursorListItem of this.shadowRoot.querySelectorAll("#cursor-list li")) {
+          for (const cursorListItem of this.shadowRoot.querySelectorAll(
+            "#cursor-list li"
+          )) {
             if (newCursor === cursorListItem.getAttribute("cursor")) {
               cursorListItem.classList.add("nav-selected");
             } else {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -33,7 +33,9 @@
 
         <shutdown-dialog id="shutdown-dialog"></shutdown-dialog>
         <update-dialog id="update-dialog"></update-dialog>
-        <change-hostname-dialog id="change-hostname-dialog"></change-hostname-dialog>
+        <change-hostname-dialog
+          id="change-hostname-dialog"
+        ></change-hostname-dialog>
         <debug-dialog id="debug-dialog"></debug-dialog>
 
         <remote-screen

--- a/dev-scripts/check-frontend-format
+++ b/dev-scripts/check-frontend-format
@@ -9,4 +9,4 @@ set -x
 # Exit on unset variable.
 set -u
 
-./node_modules/.bin/prettier --check app/static
+./node_modules/.bin/prettier --check app


### PR DESCRIPTION
There was a bug in the CI config for Prettier, so it was failing to format files in app/templates. This fixes the formatting and corrects the bug in the CI config.

This is a pure refactoring change. I just ran Prettier over the files that it was missing, so this should have no functional effects.

The one exception is that I fixed an unclosed HTML tag in app/templates/custom-elements/connection-indicator.html.