### PR TITLE
Introduce CSS colour variables

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2,6 +2,32 @@
 @import "cursors.css";
 @import "keyboard-panel.css";
 
+:root {
+  --brand-hue-metallic: 230;
+  --brand-hue-blue: 230;
+  --brand-hue-yellow: 35;
+  --brand-hue-red: 5;
+  --brand-hue-green: 135;
+
+  --brand-metallic-dark: hsl(var(--brand-hue-blue), 33%, 33%);
+  --brand-metallic-medium: hsl(var(--brand-hue-metallic), 19%, 40%);
+  --brand-metallic-light: hsl(var(--brand-hue-metallic), 16%, 55%);
+  --brand-metallic-bright: hsl(var(--brand-hue-metallic), 18%, 71%);
+
+  --brand-sand-light: hsl(var(--brand-hue-yellow), 59%, 92%);
+  --brand-creme-light: hsl(var(--brand-hue-yellow), 60%, 97%);
+
+  --brand-blue: hsl(var(--brand-hue-blue), 80%, 60%);
+
+  --brand-red: hsl(var(--brand-hue-red), 55%, 40%);
+  --brand-red-light: hsl(var(--brand-hue-red), 52%, 80%);
+  --brand-red-bright: hsl(var(--brand-hue-red), 85%, 46%);
+
+  --brand-green: hsl(var(--brand-hue-green), 40%, 45%);
+  --brand-green-light: hsl(var(--brand-hue-green), 42%, 73%);
+  --brand-green-bright: hsl(var(--brand-hue-green), 70%, 45%);
+}
+
 body {
   margin: 0;
   background: rgb(114, 114, 114);


### PR DESCRIPTION
These colours were taken over from the redesign proposal in https://github.com/mtlynch/tinypilot/pull/548.

They are not used yet, so this PR doesn’t have any observable effect other than making these variables available for subsequent PRs to build on.

<img width="654" alt="Screenshot 2021-03-05 at 18 46 34" src="https://user-images.githubusercontent.com/3618384/110153287-23680580-7de3-11eb-95ff-c47a228d40a9.png">
