### PR TITLE
Replace all inline colour definitions by the central ones

### DIFF
--- a/app/static/css/button.css
+++ b/app/static/css/button.css
@@ -1,10 +1,12 @@
+@import "style.css";
+
 button {
   display: inline-block;
   border: none;
   padding: 1rem 2rem;
   margin: 1rem;
   text-decoration: none;
-  background: #0069ed;
+  background: var(--brand-metallic-light);
   color: #ffffff;
   font-size: 1rem;
   cursor: pointer;
@@ -16,7 +18,7 @@ button {
 
 button:hover,
 button:focus {
-  background: #0053ba;
+  background-color: var(--brand-metallic-bright);
 }
 
 button:focus {
@@ -29,9 +31,9 @@ button:active {
 }
 
 button.btn-success {
-  background-color: rgb(15, 157, 88);
+  background-color: var(--brand-green);
 }
 
 button.btn-success:hover {
-  background-color: rgb(65, 177, 108);
+  background-color: var(--brand-green-bright);
 }

--- a/app/static/css/keyboard-panel.css
+++ b/app/static/css/keyboard-panel.css
@@ -1,9 +1,11 @@
+@import "style.css";
+
 #keystroke-panel {
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
-  background-color: rgb(252, 236, 223);
-  border: 1px solid rgb(139, 97, 62);
+  background-color: var(--brand-sand-light);
+  border: 1px solid var(--brand-metallic-dark);
   margin: 2rem auto;
   padding: 1rem;
   color: black;

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -30,7 +30,7 @@
 
 body {
   margin: 0;
-  background: rgb(114, 114, 114);
+  background: var(--brand-creme-light);
 }
 
 .container {
@@ -58,7 +58,7 @@ h4,
 }
 
 a {
-  color: rgb(192, 255, 110);
+  color: var(--brand-blue);
   text-decoration: none;
 }
 
@@ -72,8 +72,8 @@ img {
 
 #error-panel {
   display: none;
-  background-color: rgb(255, 133, 133);
-  border: 2px solid rgb(175, 1, 1);
+  background-color: var(--brand-red-light);
+  border: 2px solid var(--brand-red);
   max-width: 800px;
   padding: 1rem 3rem;
   margin: 0 auto 1rem auto;

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -1,5 +1,6 @@
 <template id="change-hostname-template">
   <style>
+    @import "css/style.css";
     @import "css/button.css";
 
     .overlay {
@@ -49,8 +50,8 @@
     }
 
     #change-hostname-panel > div {
-      background-color: rgb(252, 236, 223);
-      border: 1px solid rgb(139, 97, 62);
+      background-color: var(--brand-creme-light);
+      border: 1px solid var(--brand-metallic-dark);
       max-width: 800px;
       margin: 100px auto 0rem auto;
       padding: 2rem;
@@ -64,16 +65,16 @@
     }
 
     #change-and-restart {
-      background-color: rgb(15, 157, 88);
+      background-color: var(--brand-green);
     }
 
     #change-and-restart:disabled {
-      background-color: rgb(117, 202, 161);
+      background-color: var(--brand-green-light);
       cursor: not-allowed;
     }
 
     #change-and-restart:hover {
-      background-color: rgb(65, 177, 108);
+      background-color: var(--brand-green-bright);
     }
 
     .input-container {
@@ -81,7 +82,7 @@
     }
 
     #input-error {
-      color: rgb(153, 8, 8);
+      color: var(--brand-red);
       font-weight: bold;
     }
   </style>

--- a/app/templates/custom-elements/connection-indicator.html
+++ b/app/templates/custom-elements/connection-indicator.html
@@ -19,13 +19,11 @@
       border-radius: 50%;
       display: inline-block;
       /* Disconnected state */
-      border: 1px solid rgb(255, 82, 82);
-      background-color: red;
+      background-color: 1px solid var(--brand-red-bright);
     }
 
     :host([connected="true"]) .status-dot {
-      border: 1px solid rgb(190, 255, 170);
-      background-color: rgb(116, 238, 116);
+      background-color: var(--brand-green-bright);
     }
 
     .connected-text {

--- a/app/templates/custom-elements/debug-dialog.html
+++ b/app/templates/custom-elements/debug-dialog.html
@@ -1,5 +1,6 @@
 <template id="debug-dialog-template">
   <style>
+    @import "css/style.css";
     @import "css/button.css";
 
     .overlay {
@@ -44,8 +45,8 @@
     }
 
     #panel > div {
-      background-color: rgb(252, 236, 223);
-      border: 1px solid rgb(139, 97, 62);
+      background-color: var(--brand-creme-light);
+      border: 1px solid var(--brand-metallic-dark);
       max-width: 1000px;
       margin: 100px auto 0rem auto;
       padding: 2rem;
@@ -53,8 +54,8 @@
 
     #logs-success .logs {
       font-family: consolas, monospace;
-      background-color: #f1f1f1;
-      border: 1px solid #302e28;
+      background-color: white;
+      border: 1px solid var(--brand-metallic-dark);
       user-select: text;
       text-align: left;
       overflow-y: scroll;
@@ -73,7 +74,7 @@
     }
 
     .error {
-      color: rgb(153, 8, 8);
+      color: var(--brand-red);
       user-select: text;
       white-space: pre-wrap;
     }

--- a/app/templates/custom-elements/key-history-card.html
+++ b/app/templates/custom-elements/key-history-card.html
@@ -1,10 +1,12 @@
 <template id="key-history-card-template">
   <style>
+    @import "css/style.css";
+
     .key-card {
       margin: 1rem;
       padding: 1rem;
       display: block;
-      background-color: aliceblue;
+      background-color: var(--brand-metallic-light);
       font-family: "Courier New", Courier, monospace;
       border: 1px solid gray;
       width: 40px;
@@ -12,11 +14,11 @@
     }
 
     :host([result="succeeded"]) .key-card {
-      background-color: rgb(168, 255, 168);
+      background-color: var(--brand-green-light);
     }
 
     :host([result="failed"]) .key-card {
-      background-color: red;
+      background-color: var(--brand-red);
     }
   </style>
   <div class="key-card"></div>

--- a/app/templates/custom-elements/menubar.html
+++ b/app/templates/custom-elements/menubar.html
@@ -1,5 +1,6 @@
 <template id="menu-bar-template">
   <style>
+    @import "css/style.css";
     @import "css/cursors.css";
 
     a {
@@ -39,7 +40,7 @@
       padding: 0 2rem;
       margin: 0;
       color: white;
-      background-color: rgb(42, 42, 143);
+      background-color: var(--brand-metallic-dark);
       border-bottom: 1px solid black;
       margin-bottom: 1rem;
       -webkit-touch-callout: none;
@@ -94,9 +95,7 @@
     }
 
     .group a {
-      background-color: rgb(25, 7, 126);
       padding: 0.7rem 1.3rem;
-      border: 1px solid rgb(72, 61, 131);
     }
 
     .group > ul > a:after {
@@ -105,11 +104,11 @@
     }
 
     .group ul a:hover {
-      background: rgb(148 134 226);
+      background: var(--brand-metallic-light);
     }
 
     .group ul a {
-      background-color: rgb(65, 50, 146);
+      background-color: var(--brand-metallic-medium);
     }
 
     .subgroup:after {

--- a/app/templates/custom-elements/progress-spinner.html
+++ b/app/templates/custom-elements/progress-spinner.html
@@ -1,9 +1,11 @@
 <template id="progress-spinner-template">
   <style>
+    @import "css/style.css";
+
     .spinner {
       margin: auto;
-      border: 10px solid #e6d4c8;
-      border-top: 10px solid #664bd2;
+      border: 10px solid var(--brand-metallic-bright);
+      border-top: 10px solid var(--brand-blue);
       border-radius: 50%;
       width: 60px;
       height: 60px;

--- a/app/templates/custom-elements/remote-screen.html
+++ b/app/templates/custom-elements/remote-screen.html
@@ -2,10 +2,6 @@
   <style>
     @import "css/cursors.css";
 
-    .screen-wrapper {
-      background: rgb(114, 114, 114);
-    }
-
     #remote-screen-img {
       max-width: 100%;
       max-height: 1080px;

--- a/app/templates/custom-elements/shutdown-dialog.html
+++ b/app/templates/custom-elements/shutdown-dialog.html
@@ -1,5 +1,6 @@
 <template id="shutdown-dialog-template">
   <style>
+    @import "css/style.css";
     @import "css/button.css";
 
     .overlay {
@@ -49,19 +50,19 @@
     }
 
     #shutdown-confirmation-panel > div {
-      background-color: rgb(252, 236, 223);
-      border: 1px solid rgb(139, 97, 62);
+      background-color: var(--brand-creme-light);
+      border: 1px solid var(--brand-metallic-dark);
       max-width: 800px;
       margin: 100px auto 0rem auto;
       padding: 2rem;
     }
 
     .btn-danger {
-      background-color: rgb(153, 8, 8);
+      background-color: var(--brand-red);
     }
 
     .btn-danger:hover {
-      background-color: rgb(223, 48, 48);
+      background-color: var(--brand-red-bright);
     }
   </style>
   <div id="shutdown-confirmation-panel" class="overlay">

--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -1,5 +1,6 @@
 <template id="update-dialog-template">
   <style>
+    @import "css/style.css";
     @import "css/button.css";
 
     .overlay {
@@ -59,8 +60,8 @@
     }
 
     #update-panel > div {
-      background-color: rgb(252, 236, 223);
-      border: 1px solid rgb(139, 97, 62);
+      background-color: var(--brand-creme-light);
+      border: 1px solid var(--brand-metallic-dark);
       max-width: 800px;
       margin: 100px auto 0rem auto;
       padding: 2rem;


### PR DESCRIPTION
This PR (part of https://github.com/mtlynch/tinypilot/pull/548) replaces all inlined colour definitions with the ones centrally defined in `style.css` (#550). The only inline colours left are gray tones. This is okay, since it’s often hard to impossible to really unify all gray shades.

`screen-wrapper` doesn’t need his own bg colour, since the `body` bg is defined as `--brand-creme-light`.

<img width="589" alt="Screenshot 2021-03-05 at 19 14 51" src="https://user-images.githubusercontent.com/3618384/110156480-4dbbc200-7de7-11eb-83ac-cf3d8d998487.png">
