### PR TITLE
Refactoring: don’t repeat button definitions, use the centrally defined ones

### DIFF
--- a/app/static/css/button.css
+++ b/app/static/css/button.css
@@ -37,3 +37,16 @@ button.btn-success {
 button.btn-success:hover {
   background-color: var(--brand-green-bright);
 }
+
+button.btn-success:disabled {
+  background-color: var(--brand-green-light);
+  cursor: not-allowed;
+}
+
+.btn-danger {
+  background-color: var(--brand-red);
+}
+
+.btn-danger:hover {
+  background-color: var(--brand-red-bright);
+}

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -64,19 +64,6 @@
       padding: 0.3rem;
     }
 
-    #change-and-restart {
-      background-color: var(--brand-green);
-    }
-
-    #change-and-restart:disabled {
-      background-color: var(--brand-green-light);
-      cursor: not-allowed;
-    }
-
-    #change-and-restart:hover {
-      background-color: var(--brand-green-bright);
-    }
-
     .input-container {
       margin: 1.5rem 0;
     }
@@ -102,7 +89,7 @@
         <input type="text" id="hostname-input" size="30" />
         <p id="input-error"><!-- Filled programmatically --></p>
       </div>
-      <button id="change-and-restart" type="button">
+      <button id="change-and-restart" class="btn-success" type="button">
         Change and restart
       </button>
       <button id="cancel-hostname-change" type="button">Cancel</button>

--- a/app/templates/custom-elements/shutdown-dialog.html
+++ b/app/templates/custom-elements/shutdown-dialog.html
@@ -56,14 +56,6 @@
       margin: 100px auto 0rem auto;
       padding: 2rem;
     }
-
-    .btn-danger {
-      background-color: var(--brand-red);
-    }
-
-    .btn-danger:hover {
-      background-color: var(--brand-red-bright);
-    }
   </style>
   <div id="shutdown-confirmation-panel" class="overlay">
     <div id="prompt">


### PR DESCRIPTION
The hostname panel used to repeat the button definition of the success button for no good reason. Also, `btn-danger` should live in `button.css`.