### PR TITLE
Change font to sans-serif

### DIFF
--- a/app/static/css/button.css
+++ b/app/static/css/button.css
@@ -9,6 +9,7 @@ button {
   background: var(--brand-metallic-light);
   color: #ffffff;
   font-size: 1rem;
+  font-family: inherit;
   cursor: pointer;
   text-align: center;
   transition: background 250ms ease-in-out, transform 150ms ease;

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -41,25 +41,26 @@ body {
   margin: 0 auto;
 }
 
-* {
-  font-family: Lora;
+html {
+  font-family: "Overpass", sans-serif;
 }
 
 *:focus {
   outline: none;
 }
 
-h1,
-h2,
-h3,
-h4,
-.brand {
-  font-family: Nunito;
+p {
+  line-height: 1.6;
 }
 
 a {
   color: var(--brand-blue);
   text-decoration: none;
+}
+
+.monospace {
+  font-family: "Overpass Mono", monospace;
+  font-size: 0.9em;
 }
 
 img {

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -59,8 +59,6 @@
 
     #hostname-input {
       margin: 0 auto;
-      font-family: monospace;
-      font-size: 1.1rem;
       padding: 0.3rem;
     }
 
@@ -86,7 +84,7 @@
       </p>
       <div class="input-container">
         <label for="hostname-input">Hostname:</label>
-        <input type="text" id="hostname-input" size="30" />
+        <input type="text" id="hostname-input" size="30" class="monospace" />
         <p id="input-error"><!-- Filled programmatically --></p>
       </div>
       <button id="change-and-restart" class="btn-success" type="button">

--- a/app/templates/custom-elements/connection-indicator.html
+++ b/app/templates/custom-elements/connection-indicator.html
@@ -15,7 +15,7 @@
     .status-dot {
       height: 1rem;
       width: 1rem;
-      margin-left: 0.8rem;
+      margin: 0 0 0.1rem 0.6rem;
       border-radius: 50%;
       display: inline-block;
       /* Disconnected state */
@@ -43,14 +43,16 @@
     }
   </style>
   <div class="status">
-    <p>Connection</p>
+    <div>Connection</div>
     <content-tooltip position="bottom">
       <span class="status-dot"></span>
-      <p slot="text" class="connected-text">You are connected to TinyPilot.</p>
-      <p slot="text" class="disconnected-text">
+      <div slot="text" class="connected-text">
+        You are connected to TinyPilot.
+      </div>
+      <div slot="text" class="disconnected-text">
         Could not connect to TinyPilot:
         <span id="disconnect-reason"></span>
-      </p>
+      </div>
     </content-tooltip>
   </div>
 </template>

--- a/app/templates/custom-elements/debug-dialog.html
+++ b/app/templates/custom-elements/debug-dialog.html
@@ -53,7 +53,7 @@
     }
 
     #logs-success .logs {
-      font-family: consolas, monospace;
+      padding: 0.25rem 0.5rem;
       background-color: white;
       border: 1px solid var(--brand-metallic-dark);
       user-select: text;
@@ -75,6 +75,7 @@
 
     .error {
       color: var(--brand-red);
+      font-weight: bold;
       user-select: text;
       white-space: pre-wrap;
     }
@@ -87,7 +88,7 @@
     </div>
     <div id="logs-success">
       <h3>Debug Logs</h3>
-      <p class="logs"></p>
+      <p class="logs monospace"></p>
       <button class="share-btn btn-success" type="button">
         Get shareable URL
       </button>

--- a/app/templates/custom-elements/key-history-card.html
+++ b/app/templates/custom-elements/key-history-card.html
@@ -7,7 +7,6 @@
       padding: 1rem;
       display: block;
       background-color: var(--brand-metallic-light);
-      font-family: "Courier New", Courier, monospace;
       border: 1px solid gray;
       width: 40px;
       height: 24px;
@@ -19,9 +18,10 @@
 
     :host([result="failed"]) .key-card {
       background-color: var(--brand-red);
+      color: white;
     }
   </style>
-  <div class="key-card"></div>
+  <div class="key-card monospace"></div>
 </template>
 
 <script>

--- a/app/templates/custom-elements/menubar.html
+++ b/app/templates/custom-elements/menubar.html
@@ -7,7 +7,6 @@
       color: white;
       display: block;
       text-decoration: none;
-      padding: 5px 15px;
     }
 
     a:hover {
@@ -22,27 +21,26 @@
     li {
       display: block;
       position: relative;
-      margin-left: 1.5rem;
       list-style: none;
     }
 
     li:hover > ul {
       visibility: visible;
       opacity: 1;
-      -webkit-transition: 0.7s;
-      transition: 0.7s;
+      -webkit-transition: 0.3s;
+      transition: 0.3s;
     }
 
     :host {
       display: flex;
+      height: 45px;
       flex-direction: row;
       align-items: center;
       padding: 0 2rem;
-      margin: 0;
+      margin: 0 0 12px 0;
       color: white;
       background-color: var(--brand-metallic-dark);
-      border-bottom: 1px solid black;
-      margin-bottom: 1rem;
+      box-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
       -webkit-touch-callout: none;
       -webkit-user-select: none;
       -khtml-user-select: none;
@@ -52,27 +50,73 @@
     }
 
     .logo {
-      margin: 1rem 0 0.6rem 0;
+      position: relative;
+      box-sizing: border-box;
+      height: 90%;
+      padding: 6px 0;
+      margin-right: 1rem;
     }
 
     .logo img {
-      max-width: 200px;
+      height: 100%;
+      position: relative;
     }
 
-    .groups {
-      flex-grow: 1;
+    .logo:before {
+      /* This creates a subtle glow behind tiny-hamster in the logo, which
+         makes him shine a bit better on the background. */
+      content: "";
+      position: absolute;
+      top: 10px;
+      left: 1px;
+      height: 25px;
+      width: 25px;
+      background-color: rgba(189, 215, 223, 0.2);
+      filter: blur(5px);
+    }
+
+    .header-item {
+      box-sizing: border-box;
       display: flex;
-      flex-direction: row;
       align-items: center;
+      height: 100%;
+      padding-top: 3px;
     }
 
     .items {
       position: absolute;
-      left: 0;
+      left: -0.85rem;
       top: 100%;
       visibility: hidden;
       opacity: 0;
       min-width: 12em;
+    }
+
+    .item a {
+      padding: 0.5em 0.8em;
+    }
+
+    .group {
+      display: flex;
+      z-index: 1;
+      margin-left: 2rem;
+      padding-right: 17px;
+      height: 100%;
+      align-items: center;
+    }
+
+    .group > a:after {
+      --width: 5px;
+      --height: 7px;
+      content: "";
+      position: absolute;
+      top: 17px;
+      right: 0;
+      width: 0;
+      height: 0;
+      border-left: var(--width) solid transparent;
+      border-right: var(--width) solid transparent;
+      border-top: var(--height) solid var(--brand-creme-light);
     }
 
     .subgroup .items {
@@ -85,24 +129,6 @@
       padding: 0;
     }
 
-    .group {
-      z-index: 1;
-    }
-
-    .group > a:after {
-      content: "▾";
-      margin-left: 0.5em;
-    }
-
-    .group a {
-      padding: 0.7rem 1.3rem;
-    }
-
-    .group > ul > a:after {
-      content: "▾";
-      margin-left: 1em;
-    }
-
     .group ul a:hover {
       background: var(--brand-metallic-light);
     }
@@ -112,10 +138,17 @@
     }
 
     .subgroup:after {
-      content: "▸";
+      --width: 5px;
+      --height: 7px;
+      content: "";
       position: absolute;
-      right: 5px;
-      top: 11px;
+      top: 13px;
+      right: 11px;
+      width: 0;
+      height: 0;
+      border-top: var(--width) solid transparent;
+      border-bottom: var(--width) solid transparent;
+      border-left: var(--height) solid var(--brand-creme-light);
     }
 
     #cursor-list a {
@@ -123,21 +156,24 @@
     }
 
     .connection-indicator {
-      margin-right: 0.5rem;
+      margin-right: 2rem;
       margin-left: auto;
     }
 
     .nav-icon img {
+      margin-top: 5px;
       max-height: 22px;
     }
 
-    .nav-selected a {
-      background: #241e7f !important;
+    .nav-selected a:after {
+      content: "✓";
+      position: absolute;
+      right: 10px;
     }
   </style>
 
   <div class="logo"><img src="/img/slim-logo-white.png" /></div>
-  <ul class="groups">
+  <ul class="groups header-item">
     <li class="group">
       <a>System</a>
       <ul class="items">
@@ -182,18 +218,17 @@
         </li>
       </ul>
     </li>
-
-    <li class="connection-indicator">
-      <!-- The connection indicator will be moved
-        to the status bar later on -->
-      <connection-indicator id="connection-indicator"> </connection-indicator>
-    </li>
-    <li class="nav-icon">
-      <a href="https://github.com/mtlynch/tinypilot" target="_blank">
-        <img src="/img/GitHub-Mark-Light-120px-plus.png" />
-      </a>
-    </li>
   </ul>
+  <div class="header-item connection-indicator">
+    <!-- The connection indicator will be moved
+      to the status bar later on -->
+    <connection-indicator id="connection-indicator"> </connection-indicator>
+  </div>
+  <div class="header-item nav-icon">
+    <a href="https://github.com/mtlynch/tinypilot" target="_blank">
+      <img src="/img/GitHub-Mark-Light-120px-plus.png" />
+    </a>
+  </div>
 </template>
 
 <script>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -4,8 +4,9 @@
     <meta charset="utf-8" />
     <title>TinyPilot</title>
     <link rel="stylesheet" type="text/css" href="/css/style.css" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Lora&family=Nunito&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Overpass:wght@300;600&family=Overpass+Mono:wght@300&display=swap"
       rel="stylesheet"
     />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />


### PR DESCRIPTION
As discussed in https://github.com/mtlynch/tinypilot/pull/548 we want to change to a sans-serif typeface to create a more professional look and feel. Therefore we switch to the font “Overpass” in this PR, which also happens to come with a matching monospace variant.

<img width="814" alt="Screenshot 2021-03-05 at 20 20 58" src="https://user-images.githubusercontent.com/3618384/110165059-988f0700-7df2-11eb-9854-d2192501c8a9.png">

Some CSS had to be adjusted to account for the different spacing behaviour of the new font. The size of the header bar was slimmed down to `45px` to make the look consistent.

## Minor remarks
- `*` is not necessary for declaring a font, the font properties get inherited from the root element. (Except for form elements, see `button.css`.) It’s generally better to inherit font properties if possible, rather than targeting all elements.
- I changed the pattern for indicating the selected mouse cursor from “blue background colour” to a “✓” checkmark icon. I find it clearer in terms of communication, plus we don’t have to introduce a new colour only for that purpose.