### PR TITLE
Setup style guide for internal usage

### DIFF
--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>TinyPilot Styleguide</title>
+    <link rel="stylesheet" type="text/css" href="/css/style.css" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Overpass:wght@300;600&family=Overpass+Mono:wght@300&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <style>
+    main {
+      margin: 1rem auto;
+      width: 40rem;
+    }
+    .colorcard {
+      float: left;
+      height: 5rem;
+      min-width: 10rem;
+    }
+  </style>
+  <body>
+    <main>
+      <div
+        style="
+          background-color: var(--brand-metallic-dark);
+          text-align: center;
+          padding: 1rem;
+        "
+      >
+        <img src="/img/slim-logo-white.png" alt="Tiny Pilot" />
+      </div>
+      <h2 style="text-align: center;">Style guide</h2>
+      <p>
+        This style guide is an ongoing collection of all things visual that make
+        up the brand, such as colours, fonts, patterns or UI components.
+      </p>
+      <div>
+        <div
+          class="colorcard"
+          style="background-color: var(--brand-metallic-dark);"
+        ></div>
+        <div
+          class="colorcard"
+          style="background-color: var(--brand-metallic-medium);"
+        ></div>
+        <div
+          class="colorcard"
+          style="background-color: var(--brand-metallic-light);"
+        ></div>
+        <div
+          class="colorcard"
+          style="background-color: var(--brand-metallic-bright);"
+        ></div>
+        <br style="clear: both;" />
+        <div
+          class="colorcard"
+          style="background-color: var(--brand-blue);"
+        ></div>
+        <br style="clear: both;" />
+        <div
+          class="colorcard"
+          style="background-color: var(--brand-red);"
+        ></div>
+        <div
+          class="colorcard"
+          style="background-color: var(--brand-red-light);"
+        ></div>
+        <br style="clear: both;" />
+        <div
+          class="colorcard"
+          style="background-color: var(--brand-green);"
+        ></div>
+        <div
+          class="colorcard"
+          style="background-color: var(--brand-green-light);"
+        ></div>
+        <br style="clear: both;" />
+        <div
+          class="colorcard"
+          style="background-color: var(--brand-sand-light);"
+        ></div>
+      </div>
+    </main>
+  </body>
+</html>

--- a/app/views.py
+++ b/app/views.py
@@ -11,6 +11,15 @@ def index_get():
         'index.html', custom_elements_files=find_files.custom_elements_files())
 
 
+# The style guide is for development purpose only, so we don’t ship it to
+# end users.
+@views_blueprint.route('/styleguide', methods=['GET'])
+def styleguide_get():
+    if flask.current_app.debug:
+        return flask.render_template('styleguide.html')
+    return flask.abort(404)
+
+
 # On a real install, nginx redirects the /stream route to uStreamer, so a real
 # user should never hit this route in production. In development, show a fake
 # still image to give a better sense of how the TinyPilot UI looks.


### PR DESCRIPTION
As discussed in https://github.com/mtlynch/tinypilot/pull/548 it can be helpful to have an ongoing collection of all visual patterns and elements that are used across the app. This helps in the longer run to keep the UI consistent, and it also promotes reusability of UI components.

I made good experiences working with style guides, even on smaller projects. If it doesn’t turn out to be helpful for us, we can ditch it anytime.

The style guide is only shown when `debug` is turned on.