### PR TITLE
Fix connection indicator in status bar

### DIFF
--- a/app/templates/custom-elements/connection-indicator.html
+++ b/app/templates/custom-elements/connection-indicator.html
@@ -19,7 +19,7 @@
       border-radius: 50%;
       display: inline-block;
       /* Disconnected state */
-      background-color: 1px solid var(--brand-red-bright);
+      background-color: var(--brand-red-bright);
     }
 
     :host([connected="true"]) .status-dot {


### PR DESCRIPTION
That one slipped through. (Red icon was not shown due to this.)