### PR TITLE
Give users the option to toggle virtual keyboard

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -23,6 +23,10 @@ function showElementById(id, display = "block") {
   document.getElementById(id).style.display = display;
 }
 
+function isElementShown(id) {
+  return document.getElementById(id).style.display !== "none";
+}
+
 function showError(errorType, errorMessage) {
   document.getElementById("error-type").innerText = errorType;
   document.getElementById("error-message").innerText = errorMessage;
@@ -253,6 +257,16 @@ function setCursor(cursor, save = true) {
   }
 }
 
+function setKeyboardVisibility(isVisible) {
+  if (isVisible) {
+    showElementById("keystroke-panel");
+  } else {
+    hideElementById("keystroke-panel");
+  }
+  settings.setKeyboardVisibility(isVisible);
+  document.getElementById("menu-bar").isKeyboardVisible = isVisible;
+}
+
 document.onload = document.getElementById("app").focus();
 
 document.addEventListener("keydown", onKeyDown);
@@ -261,8 +275,10 @@ document.addEventListener("keyup", onKeyUp);
 const menuBar = document.getElementById("menu-bar");
 menuBar.cursor = settings.getScreenCursor();
 menuBar.onChangeCursor = setCursor;
-menuBar.showKeyboard = settings.getShowKeyboard();
-menuBar.showKeyboardCallback = (isShown) => settings.setShowKeyboard(isShown);
+menuBar.addEventListener("keyboard-visibility-toggled", () => {
+  setKeyboardVisibility(!isElementShown("keystroke-panel"));
+});
+setKeyboardVisibility(settings.isKeyboardVisible());
 
 document
   .getElementById("remote-screen")

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -261,6 +261,7 @@ document.addEventListener("keyup", onKeyUp);
 const menuBar = document.getElementById("menu-bar");
 menuBar.cursor = settings.getScreenCursor();
 menuBar.onChangeCursor = setCursor;
+menuBar.showKeyboard = true;
 
 document
   .getElementById("remote-screen")

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -261,7 +261,8 @@ document.addEventListener("keyup", onKeyUp);
 const menuBar = document.getElementById("menu-bar");
 menuBar.cursor = settings.getScreenCursor();
 menuBar.onChangeCursor = setCursor;
-menuBar.showKeyboard = true;
+menuBar.showKeyboard = settings.getShowKeyboard();
+menuBar.showKeyboardCallback = (isShown) => settings.setShowKeyboard(isShown);
 
 document
   .getElementById("remote-screen")

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -6,6 +6,7 @@ try {
 const defaults = {
   isKeyHistoryEnabled: true,
   cursor: "crosshair",
+  showKeyboard: true,
 };
 
 // Initialize any undefined settings to their default values.
@@ -42,5 +43,14 @@ export function getScreenCursor() {
 
 export function setScreenCursor(newCursor) {
   settings["cursor"] = newCursor;
+  persistSettings();
+}
+
+export function getShowKeyboard() {
+  return settings["showKeyboard"];
+}
+
+export function setShowKeyboard(isShown) {
+  settings["showKeyboard"] = isShown;
   persistSettings();
 }

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -6,7 +6,7 @@ try {
 const defaults = {
   isKeyHistoryEnabled: true,
   cursor: "crosshair",
-  showKeyboard: true,
+  isKeyboardVisible: true,
 };
 
 // Initialize any undefined settings to their default values.
@@ -46,11 +46,11 @@ export function setScreenCursor(newCursor) {
   persistSettings();
 }
 
-export function getShowKeyboard() {
-  return settings["showKeyboard"];
+export function isKeyboardVisible() {
+  return settings["isKeyboardVisible"];
 }
 
-export function setShowKeyboard(isShown) {
-  settings["showKeyboard"] = isShown;
+export function setKeyboardVisibility(isVisible) {
+  settings["isKeyboardVisible"] = isVisible;
   persistSettings();
 }

--- a/app/templates/custom-elements/menubar.html
+++ b/app/templates/custom-elements/menubar.html
@@ -246,7 +246,6 @@
         constructor() {
           super();
           this.setCursorCallback = () => {};
-          this.showKeyboardCallback = () => {};
         }
 
         connectedCallback() {

--- a/app/templates/custom-elements/menubar.html
+++ b/app/templates/custom-elements/menubar.html
@@ -213,6 +213,9 @@
             <!-- JavaScript populates this list dynamically. -->
           </ul>
         </li>
+        <li class="item" id="keyboard-menu-item">
+          <a id="keyboard-btn">Show Keyboard</a>
+        </li>
         <li class="item">
           <a id="fullscreen-btn">Full Screen</a>
         </li>
@@ -259,6 +262,12 @@
             .addEventListener("click", (evt) => {
               evt.target.download =
                 "TinyPilot-" + new Date().toISOString() + ".jpg";
+            });
+          this.shadowRoot
+            .getElementById("keyboard-btn")
+            .addEventListener("click", (evt) => {
+              this.showKeyboard = !this.showKeyboard;
+              evt.preventDefault();
             });
           this.shadowRoot
             .getElementById("fullscreen-btn")
@@ -316,6 +325,23 @@
             listItem.setAttribute("cursor", cursorOption);
             cursorList.appendChild(listItem);
           }
+        }
+
+        set showKeyboard(isShown) {
+          const keystrokePanel = document.getElementById("keystroke-panel");
+          const keyboardMenuItem = this.shadowRoot.getElementById("keyboard-menu-item");
+          if (isShown) {
+            keystrokePanel.style.display = "block";
+            keyboardMenuItem.classList.add("nav-selected");
+          } else {
+            keystrokePanel.style.display = "none";
+            keyboardMenuItem.classList.remove("nav-selected");
+          }
+        }
+
+        get showKeyboard() {
+          const keystrokePanel = document.getElementById("keystroke-panel");
+          return keystrokePanel.style.display === "block";
         }
 
         get connectionIndicator() {

--- a/app/templates/custom-elements/menubar.html
+++ b/app/templates/custom-elements/menubar.html
@@ -267,7 +267,7 @@
           this.shadowRoot
             .getElementById("keyboard-btn")
             .addEventListener("click", (evt) => {
-              this.showKeyboard = !this.showKeyboard;
+              this.emitKeyboardVisibilityToggledEvent();
               evt.preventDefault();
             });
           this.shadowRoot
@@ -328,28 +328,22 @@
           }
         }
 
-        set showKeyboard(isShown) {
-          const keystrokePanel = document.getElementById("keystroke-panel");
-          const keyboardMenuItem = this.shadowRoot.getElementById(
-            "keyboard-menu-item"
-          );
-          if (isShown) {
-            keystrokePanel.style.display = "block";
-            keyboardMenuItem.classList.add("nav-selected");
+        set isKeyboardVisible(isVisible) {
+          const menuItem = this.shadowRoot.getElementById("keyboard-menu-item");
+          if (isVisible) {
+            menuItem.classList.add("nav-selected");
           } else {
-            keystrokePanel.style.display = "none";
-            keyboardMenuItem.classList.remove("nav-selected");
+            menuItem.classList.remove("nav-selected");
           }
-          this.showKeyboardCallback(isShown);
         }
 
-        get showKeyboard() {
-          const keystrokePanel = document.getElementById("keystroke-panel");
-          return keystrokePanel.style.display === "block";
-        }
-
-        set onShowKeyboard(handler) {
-          this.showKeyboardCallback = handler;
+        emitKeyboardVisibilityToggledEvent() {
+          this.dispatchEvent(
+            new CustomEvent("keyboard-visibility-toggled", {
+              bubbles: true,
+              composed: true,
+            })
+          );
         }
 
         get connectionIndicator() {

--- a/app/templates/custom-elements/menubar.html
+++ b/app/templates/custom-elements/menubar.html
@@ -246,6 +246,7 @@
         constructor() {
           super();
           this.setCursorCallback = () => {};
+          this.showKeyboardCallback = () => {};
         }
 
         connectedCallback() {
@@ -337,11 +338,16 @@
             keystrokePanel.style.display = "none";
             keyboardMenuItem.classList.remove("nav-selected");
           }
+          this.showKeyboardCallback(isShown);
         }
 
         get showKeyboard() {
           const keystrokePanel = document.getElementById("keystroke-panel");
           return keystrokePanel.style.display === "block";
+        }
+
+        set onShowKeyboard(handler) {
+          this.showKeyboardCallback = handler;
         }
 
         get connectionIndicator() {

--- a/app/templates/custom-elements/menubar.html
+++ b/app/templates/custom-elements/menubar.html
@@ -330,7 +330,9 @@
 
         set showKeyboard(isShown) {
           const keystrokePanel = document.getElementById("keystroke-panel");
-          const keyboardMenuItem = this.shadowRoot.getElementById("keyboard-menu-item");
+          const keyboardMenuItem = this.shadowRoot.getElementById(
+            "keyboard-menu-item"
+          );
           if (isShown) {
             keystrokePanel.style.display = "block";
             keyboardMenuItem.classList.add("nav-selected");


### PR DESCRIPTION
The virtual keyboard is likely not used super frequently, so people might prefer to hide it. This PR adds a menu item with which you can show or hide the entire keyboard panel.

For now the default is to show the keyboard, as it used to be before. The reason is mainly that we don’t have the status bar yet, so the keystroke history is the only place that gives visual feedback about input events. Once we have migrated this indicator to the status bar, we can consider changing the default.

![2021-03-10 12-02-18 2021-03-10 12_03_07](https://user-images.githubusercontent.com/3618384/110621760-e1e8a900-819a-11eb-87db-dc7030673d2f.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mtlynch/tinypilot/560)
<!-- Reviewable:end -->
