### PR TITLE
Improve variable name

### DIFF
--- a/app/templates/custom-elements/menubar.html
+++ b/app/templates/custom-elements/menubar.html
@@ -242,7 +242,7 @@
       class extends HTMLElement {
         constructor() {
           super();
-          this.setCursor = () => {};
+          this.setCursorCallback = () => {};
         }
 
         connectedCallback() {
@@ -307,7 +307,7 @@
             cursorLink.setAttribute("href", "#");
             cursorLink.innerText = cursorOption;
             cursorLink.addEventListener("click", (evt) => {
-              this.setCursor(cursorOption);
+              this.setCursorCallback(cursorOption);
               evt.preventDefault();
             });
             const listItem = document.createElement("li");
@@ -335,7 +335,7 @@
         }
 
         set onChangeCursor(handler) {
-          this.setCursor = handler;
+          this.setCursorCallback = handler;
         }
       }
     );


### PR DESCRIPTION
Tiny refactoring to give clearer indication of the purpose, i.e. that this is a callback to inform the outside about an internal state change. This is inline with the naming of `showKeyboardCallback`, introduced in https://github.com/mtlynch/tinypilot/pull/560.