### PR TITLE
Refactor control flow inside menu-bar component

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -292,6 +292,11 @@ menuBar.addEventListener("change-hostname-initialized", () => {
 menuBar.addEventListener("fullscreen-requested", () => {
   document.getElementById("remote-screen").fullscreen = true;
 });
+menuBar.addEventListener("debug-logs-requested", () => {
+  const debugDialog = document.getElementById("debug-dialog");
+  debugDialog.show = true;
+  debugDialog.getLogs();
+});
 setKeyboardVisibility(settings.isKeyboardVisible());
 
 document

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -274,7 +274,9 @@ document.addEventListener("keyup", onKeyUp);
 
 const menuBar = document.getElementById("menu-bar");
 menuBar.cursor = settings.getScreenCursor();
-menuBar.onChangeCursor = setCursor;
+menuBar.addEventListener("cursor-selected", (evt) => {
+  setCursor(evt.detail.cursor);
+});
 menuBar.addEventListener("keyboard-visibility-toggled", () => {
   setKeyboardVisibility(!isElementShown("keystroke-panel"));
 });

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -286,6 +286,9 @@ menuBar.addEventListener("update-initialized", () => {
   updateDialog.show = true;
   updateDialog.checkVersion();
 });
+menuBar.addEventListener("change-hostname-initialized", () => {
+  document.getElementById("change-hostname-dialog").show = true;
+});
 setKeyboardVisibility(settings.isKeyboardVisible());
 
 document

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -278,6 +278,9 @@ menuBar.onChangeCursor = setCursor;
 menuBar.addEventListener("keyboard-visibility-toggled", () => {
   setKeyboardVisibility(!isElementShown("keystroke-panel"));
 });
+menuBar.addEventListener("shutdown-initialized", () => {
+  document.getElementById("shutdown-dialog").show = true;
+});
 setKeyboardVisibility(settings.isKeyboardVisible());
 
 document

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -280,21 +280,21 @@ menuBar.addEventListener("cursor-selected", (evt) => {
 menuBar.addEventListener("keyboard-visibility-toggled", () => {
   setKeyboardVisibility(!isElementShown("keystroke-panel"));
 });
-menuBar.addEventListener("shutdown-initialized", () => {
+menuBar.addEventListener("shutdown-dialog-requested", () => {
   document.getElementById("shutdown-dialog").show = true;
 });
-menuBar.addEventListener("update-initialized", () => {
+menuBar.addEventListener("update-dialog-requested", () => {
   const updateDialog = document.getElementById("update-dialog");
   updateDialog.show = true;
   updateDialog.checkVersion();
 });
-menuBar.addEventListener("change-hostname-initialized", () => {
+menuBar.addEventListener("change-hostname-dialog-requested", () => {
   document.getElementById("change-hostname-dialog").show = true;
 });
 menuBar.addEventListener("fullscreen-requested", () => {
   document.getElementById("remote-screen").fullscreen = true;
 });
-menuBar.addEventListener("debug-logs-requested", () => {
+menuBar.addEventListener("debug-logs-dialog-requested", () => {
   const debugDialog = document.getElementById("debug-dialog");
   debugDialog.show = true;
   debugDialog.getLogs();

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -281,6 +281,11 @@ menuBar.addEventListener("keyboard-visibility-toggled", () => {
 menuBar.addEventListener("shutdown-initialized", () => {
   document.getElementById("shutdown-dialog").show = true;
 });
+menuBar.addEventListener("update-initialized", () => {
+  const updateDialog = document.getElementById("update-dialog");
+  updateDialog.show = true;
+  updateDialog.checkVersion();
+});
 setKeyboardVisibility(settings.isKeyboardVisible());
 
 document

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -297,6 +297,9 @@ menuBar.addEventListener("debug-logs-requested", () => {
   debugDialog.show = true;
   debugDialog.getLogs();
 });
+menuBar.addEventListener("paste-requested", () => {
+  showPasteOverlay();
+});
 setKeyboardVisibility(settings.isKeyboardVisible());
 
 document

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -289,6 +289,9 @@ menuBar.addEventListener("update-initialized", () => {
 menuBar.addEventListener("change-hostname-initialized", () => {
   document.getElementById("change-hostname-dialog").show = true;
 });
+menuBar.addEventListener("fullscreen-requested", () => {
+  document.getElementById("remote-screen").fullscreen = true;
+});
 setKeyboardVisibility(settings.isKeyboardVisible());
 
 document

--- a/app/templates/custom-elements/menubar.html
+++ b/app/templates/custom-elements/menubar.html
@@ -243,11 +243,6 @@
     customElements.define(
       "menu-bar",
       class extends HTMLElement {
-        constructor() {
-          super();
-          this.setCursorCallback = () => {};
-        }
-
         connectedCallback() {
           this.attachShadow({ mode: "open" });
           this.shadowRoot.appendChild(template.content.cloneNode(true));
@@ -296,7 +291,7 @@
             cursorLink.setAttribute("href", "#");
             cursorLink.innerText = cursorOption;
             cursorLink.addEventListener("click", (evt) => {
-              this.setCursorCallback(cursorOption);
+              this.emitCustomEvent("cursor-selected", { cursor: cursorOption });
               evt.preventDefault();
             });
             const listItem = document.createElement("li");
@@ -316,9 +311,10 @@
           }
         }
 
-        emitCustomEvent(eventId) {
+        emitCustomEvent(eventId, detail) {
           this.dispatchEvent(
             new CustomEvent(eventId, {
+              detail,
               bubbles: true,
               composed: true,
             })
@@ -341,10 +337,6 @@
               cursorListItem.classList.remove("nav-selected");
             }
           }
-        }
-
-        set onChangeCursor(handler) {
-          this.setCursorCallback = handler;
         }
       }
     );

--- a/app/templates/custom-elements/menubar.html
+++ b/app/templates/custom-elements/menubar.html
@@ -283,10 +283,9 @@
             });
           this.shadowRoot
             .getElementById("update-btn")
-            .addEventListener("click", () => {
-              const updateDialog = document.getElementById("update-dialog");
-              updateDialog.show = true;
-              updateDialog.checkVersion();
+            .addEventListener("click", (evt) => {
+              this.emitCustomEvent("update-initialized");
+              evt.preventDefault();
             });
           this.shadowRoot
             .getElementById("change-hostname-btn")

--- a/app/templates/custom-elements/menubar.html
+++ b/app/templates/custom-elements/menubar.html
@@ -295,10 +295,9 @@
             });
           this.shadowRoot
             .getElementById("debug-dialog-btn")
-            .addEventListener("click", () => {
-              const debugDialog = doc.querySelector("#debug-dialog");
-              debugDialog.show = true;
-              debugDialog.getLogs();
+            .addEventListener("click", (evt) => {
+              this.emitCustomEvent("debug-logs-requested");
+              evt.preventDefault();
             });
 
           // Add cursor options to navbar.

--- a/app/templates/custom-elements/menubar.html
+++ b/app/templates/custom-elements/menubar.html
@@ -258,11 +258,13 @@
             "change-hostname-btn": "change-hostname-dialog-requested",
             "debug-dialog-btn": "debug-logs-dialog-requested",
           };
-          for (const btn in menuButtonIdToEventId) {
+          for (const [buttonId, eventId] of Object.entries(
+            menuButtonIdToEventId
+          )) {
             this.shadowRoot
-              .getElementById(btn)
+              .getElementById(buttonId)
               .addEventListener("click", (evt) => {
-                this.emitCustomEvent(menuButtonIdToEventId[btn]);
+                this.emitCustomEvent(eventId);
                 evt.preventDefault();
               });
           }

--- a/app/templates/custom-elements/menubar.html
+++ b/app/templates/custom-elements/menubar.html
@@ -254,8 +254,9 @@
 
           this.shadowRoot
             .getElementById("power-btn")
-            .addEventListener("click", () => {
-              document.getElementById("shutdown-dialog").show = true;
+            .addEventListener("click", (evt) => {
+              this.emitCustomEvent("shutdown-initialized");
+              evt.preventDefault();
             });
           this.shadowRoot
             .getElementById("screenshot-btn")

--- a/app/templates/custom-elements/menubar.html
+++ b/app/templates/custom-elements/menubar.html
@@ -252,7 +252,7 @@
           this.attachShadow({ mode: "open" });
           this.shadowRoot.appendChild(template.content.cloneNode(true));
 
-          // All “simple”/straightforward menu items, that just emit a custom
+          // All “simple”/standard menu items, that just emit a custom
           // event without any further ado.
           const menuButtonIdToEventId = {
             "power-btn": "shutdown-initialized",
@@ -326,6 +326,8 @@
         }
 
         get connectionIndicator() {
+          // Just returning the element is a bit ugly of course. However,
+          // the indicator is supposed to be moved to the status bar anyway.
           return this.shadowRoot.getElementById("connection-indicator");
         }
 

--- a/app/templates/custom-elements/menubar.html
+++ b/app/templates/custom-elements/menubar.html
@@ -289,8 +289,9 @@
             });
           this.shadowRoot
             .getElementById("change-hostname-btn")
-            .addEventListener("click", () => {
-              document.getElementById("change-hostname-dialog").show = true;
+            .addEventListener("click", (evt) => {
+              this.emitCustomEvent("change-hostname-initialized");
+              evt.preventDefault();
             });
           this.shadowRoot
             .getElementById("debug-dialog-btn")

--- a/app/templates/custom-elements/menubar.html
+++ b/app/templates/custom-elements/menubar.html
@@ -266,7 +266,7 @@
           this.shadowRoot
             .getElementById("keyboard-btn")
             .addEventListener("click", (evt) => {
-              this.emitKeyboardVisibilityToggledEvent();
+              this.emitCustomEvent("keyboard-visibility-toggled");
               evt.preventDefault();
             });
           this.shadowRoot
@@ -336,9 +336,9 @@
           }
         }
 
-        emitKeyboardVisibilityToggledEvent() {
+        emitCustomEvent(eventId) {
           this.dispatchEvent(
-            new CustomEvent("keyboard-visibility-toggled", {
+            new CustomEvent(eventId, {
               bubbles: true,
               composed: true,
             })

--- a/app/templates/custom-elements/menubar.html
+++ b/app/templates/custom-elements/menubar.html
@@ -278,8 +278,9 @@
             });
           this.shadowRoot
             .getElementById("paste-btn")
-            .addEventListener("click", () => {
-              showPasteOverlay();
+            .addEventListener("click", (evt) => {
+              this.emitCustomEvent("paste-requested");
+              evt.preventDefault();
             });
           this.shadowRoot
             .getElementById("update-btn")

--- a/app/templates/custom-elements/menubar.html
+++ b/app/templates/custom-elements/menubar.html
@@ -252,53 +252,32 @@
           this.attachShadow({ mode: "open" });
           this.shadowRoot.appendChild(template.content.cloneNode(true));
 
-          this.shadowRoot
-            .getElementById("power-btn")
-            .addEventListener("click", (evt) => {
-              this.emitCustomEvent("shutdown-initialized");
-              evt.preventDefault();
-            });
+          // All “simple”/straightforward menu items, that just emit a custom
+          // event without any further ado.
+          const menuButtonIdToEventId = {
+            "power-btn": "shutdown-initialized",
+            "keyboard-btn": "keyboard-visibility-toggled",
+            "fullscreen-btn": "fullscreen-requested",
+            "paste-btn": "paste-requested",
+            "update-btn": "update-initialized",
+            "change-hostname-btn": "change-hostname-initialized",
+            "debug-dialog-btn": "debug-logs-requested",
+          };
+          for (const btn in menuButtonIdToEventId) {
+            this.shadowRoot
+              .getElementById(btn)
+              .addEventListener("click", (evt) => {
+                this.emitCustomEvent(menuButtonIdToEventId[btn]);
+                evt.preventDefault();
+              });
+          }
+
+          // Setup screenshot button.
           this.shadowRoot
             .getElementById("screenshot-btn")
             .addEventListener("click", (evt) => {
               evt.target.download =
                 "TinyPilot-" + new Date().toISOString() + ".jpg";
-            });
-          this.shadowRoot
-            .getElementById("keyboard-btn")
-            .addEventListener("click", (evt) => {
-              this.emitCustomEvent("keyboard-visibility-toggled");
-              evt.preventDefault();
-            });
-          this.shadowRoot
-            .getElementById("fullscreen-btn")
-            .addEventListener("click", (evt) => {
-              this.emitCustomEvent("fullscreen-requested");
-              evt.preventDefault();
-            });
-          this.shadowRoot
-            .getElementById("paste-btn")
-            .addEventListener("click", (evt) => {
-              this.emitCustomEvent("paste-requested");
-              evt.preventDefault();
-            });
-          this.shadowRoot
-            .getElementById("update-btn")
-            .addEventListener("click", (evt) => {
-              this.emitCustomEvent("update-initialized");
-              evt.preventDefault();
-            });
-          this.shadowRoot
-            .getElementById("change-hostname-btn")
-            .addEventListener("click", (evt) => {
-              this.emitCustomEvent("change-hostname-initialized");
-              evt.preventDefault();
-            });
-          this.shadowRoot
-            .getElementById("debug-dialog-btn")
-            .addEventListener("click", (evt) => {
-              this.emitCustomEvent("debug-logs-requested");
-              evt.preventDefault();
             });
 
           // Add cursor options to navbar.

--- a/app/templates/custom-elements/menubar.html
+++ b/app/templates/custom-elements/menubar.html
@@ -250,13 +250,13 @@
           // All “simple”/standard menu items, that just emit a custom
           // event without any further ado.
           const menuButtonIdToEventId = {
-            "power-btn": "shutdown-initialized",
+            "power-btn": "shutdown-dialog-requested",
             "keyboard-btn": "keyboard-visibility-toggled",
             "fullscreen-btn": "fullscreen-requested",
             "paste-btn": "paste-requested",
-            "update-btn": "update-initialized",
-            "change-hostname-btn": "change-hostname-initialized",
-            "debug-dialog-btn": "debug-logs-requested",
+            "update-btn": "update-dialog-requested",
+            "change-hostname-btn": "change-hostname-dialog-requested",
+            "debug-dialog-btn": "debug-logs-dialog-requested",
           };
           for (const btn in menuButtonIdToEventId) {
             this.shadowRoot

--- a/app/templates/custom-elements/menubar.html
+++ b/app/templates/custom-elements/menubar.html
@@ -273,7 +273,7 @@
           this.shadowRoot
             .getElementById("fullscreen-btn")
             .addEventListener("click", (evt) => {
-              document.getElementById("remote-screen").fullscreen = true;
+              this.emitCustomEvent("fullscreen-requested");
               evt.preventDefault();
             });
           this.shadowRoot


### PR DESCRIPTION
As discussed in #560 the menu bar shouldn’t access the DOM directly but rather emit events to let `app.js` handle them. As a consequence, the internal setup of the menu becomes more straightforward and allows for some simplification.

No functional changes have been made.

Side note: if you have a better thought about the event names, I’m keen to hear. What I aimed for was this: a) use past tense, b) use active language (verb), c) make clear that the events are just user requests triggered through the UI, but not an actual state change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mtlynch/tinypilot/564)
<!-- Reviewable:end -->
