### PR TITLE
Floating menu

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -26,6 +26,9 @@
   --brand-green: hsl(var(--brand-hue-green), 40%, 45%);
   --brand-green-light: hsl(var(--brand-hue-green), 42%, 73%);
   --brand-green-bright: hsl(var(--brand-hue-green), 70%, 45%);
+
+  --z-index-menubar: 1;
+  --z-index-overlay: 2;
 }
 
 body {
@@ -45,7 +48,7 @@ body {
 .header-bar {
   position: fixed;
   width: 100%;
-  z-index: 999999; /* Ensure the header is always the topmost element */
+  z-index: var(--z-index-menubar);
 }
 
 html {

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -39,6 +39,13 @@ body {
   justify-content: center;
   text-align: center;
   margin: 0 auto;
+  padding-top: 55px; /* Account for menu bar plus some extra spacing */
+}
+
+.header-bar {
+  position: fixed;
+  width: 100%;
+  z-index: 999999; /* Ensure the header is always the topmost element */
 }
 
 html {

--- a/app/templates/components/paste-overlay.html
+++ b/app/templates/components/paste-overlay.html
@@ -1,4 +1,6 @@
 <style>
+  @import "css/style.css";
+
   #paste-overlay {
     display: none;
   }
@@ -9,7 +11,7 @@
     justify-content: center;
     align-items: center;
     font-size: 24pt;
-    z-index: 1;
+    z-index: var(--z-index-overlay);
     position: fixed;
     left: 0%;
     top: 0%;

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -23,7 +23,7 @@
       right: 0;
       bottom: 0;
       background-color: rgba(0, 0, 0, 0.8);
-      z-index: 2;
+      z-index: var(--z-index-overlay);
     }
 
     #initializing,

--- a/app/templates/custom-elements/debug-dialog.html
+++ b/app/templates/custom-elements/debug-dialog.html
@@ -23,7 +23,7 @@
       right: 0;
       bottom: 0;
       background-color: rgba(0, 0, 0, 0.8);
-      z-index: 2;
+      z-index: var(--z-index-overlay);
     }
 
     #logs-loading,

--- a/app/templates/custom-elements/menubar.html
+++ b/app/templates/custom-elements/menubar.html
@@ -37,7 +37,6 @@
       flex-direction: row;
       align-items: center;
       padding: 0 2rem;
-      margin: 0 0 12px 0;
       color: white;
       background-color: var(--brand-metallic-dark);
       box-shadow: 0 0 5px rgba(0, 0, 0, 0.5);

--- a/app/templates/custom-elements/shutdown-dialog.html
+++ b/app/templates/custom-elements/shutdown-dialog.html
@@ -23,7 +23,7 @@
       right: 0;
       bottom: 0;
       background-color: rgba(0, 0, 0, 0.8);
-      z-index: 2;
+      z-index: var(--z-index-overlay);
     }
 
     #prompt,

--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -23,7 +23,7 @@
       right: 0;
       bottom: 0;
       background-color: rgba(0, 0, 0, 0.8);
-      z-index: 2;
+      z-index: var(--z-index-overlay);
     }
 
     #checking,

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -23,7 +23,9 @@
     {% endfor %}
 
     <div id="app" tabindex="0">
-      <menu-bar id="menu-bar"></menu-bar>
+      <div class="header-bar">
+        <menu-bar id="menu-bar"></menu-bar>
+      </div>
 
       <div class="page-content container">
         <div id="error-panel">


### PR DESCRIPTION
In order to make the [UI feel more “appy”](https://github.com/tiny-pilot/tinypilot-pro/issues/53) the menu bar should always stay in a fixed position.

This becomes all the more important when we introduce the status bar (which I’m working on in parallel right now), because that one should never be pushed down and out of the view port. I think it would look strange, however, if only the status bar stayed fixed, but the menu bar scrolled away.

![2021-03-10 19-47-43 2021-03-10 19_49_25](https://user-images.githubusercontent.com/3618384/110681744-70c8e600-81da-11eb-86a6-3ed069084035.gif)

## Remarks
- I decided to wrap the `<menu-bar>` into an enclosing container, because that way the menu bar itself doesn’t need to know anything about it’s position on the page. The page-setup-related CSS can all reside in `style.css` and thus live closely together.
- In order to avoid entering the `z-index`-hell I pulled out all `z-index`es for fixed elements to manage them in a central place. From my experience it otherwise ends up in a mess at some point.