### PR TITLE
Add ShellCheck to Circle CI config.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,11 @@ jobs:
           command: ./dev-scripts/check-trailing-newline
   check_bash:
     docker:
-      - image: koalaman/shellcheck:latest
+      - image: koalaman/shellcheck-alpine:v0.7.1
     steps:
+      - run:
+          name: Install dependencies
+          command: apk add bash git grep
       - checkout
       - run:
           name: Run static analysis on bash scripts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,14 @@ jobs:
       - run:
           name: Check that all text files end in a trailing newline
           command: ./dev-scripts/check-trailing-newline
+  check_bash:
+    docker:
+      - image: koalaman/shellcheck:latest
+    steps:
+      - checkout
+      - run:
+          name: Run static analysis on bash scripts
+          command: ./dev-scripts/check-bash
   build_python:
     docker:
       - image: circleci/python:3.7.3
@@ -49,6 +57,7 @@ workflows:
   test:
     jobs:
       - check_whitespace
+      - check_bash
       - build_python
       - format_frontend
       - e2e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - run:
           name: Install dependencies
-          command: apk add bash git grep
+          command: apk add bash git openssh-client grep
       - checkout
       - run:
           name: Run static analysis on bash scripts

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,1 @@
+disable=SC1091

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,1 +1,3 @@
+# Stop shellcheck from complaining about references to files that don't
+# exist. They'll exist in a production environment, so these flags are noise.
 disable=SC1091

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,18 @@ python3.7 -m venv venv && \
   npm install prettier@2.0.5
 ```
 
+TinyPilot uses [ShellCheck](https://github.com/koalaman/shellcheck) to do
+static analysis on its bash scripts.
+[Install ShellCheck](https://github.com/koalaman/shellcheck#installing) through
+your package manager:
+
+```bash
+# Debian/Ubuntu/Mint
+sudo apt-get install shellcheck
+# macOS
+brew install shellcheck
+```
+
 ### Run automated tests
 
 To run TinyPilot's build scripts, run:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ The steps below show you how to quickly set up a development environment for Tin
 
 * Python 3.7 or higher
 * Node.js 13.x or higher
+* [shellcheck](https://github.com/koalaman/shellcheck#installing)
 
 ### Install packages
 
@@ -21,18 +22,6 @@ python3.7 -m venv venv && \
   pip install --requirement requirements.txt && \
   pip install --requirement dev_requirements.txt && \
   npm install prettier@2.0.5
-```
-
-TinyPilot uses [ShellCheck](https://github.com/koalaman/shellcheck) to do
-static analysis on its bash scripts.
-[Install ShellCheck](https://github.com/koalaman/shellcheck#installing) through
-your package manager:
-
-```bash
-# Debian/Ubuntu/Mint
-sudo apt-get install shellcheck
-# macOS
-brew install shellcheck
 ```
 
 ### Run automated tests

--- a/dev-scripts/build
+++ b/dev-scripts/build
@@ -11,5 +11,6 @@ set -u
 
 ./dev-scripts/check-trailing-whitespace
 ./dev-scripts/check-trailing-newline
+./dev-scripts/check-bash
 ./dev-scripts/build-python
 ./dev-scripts/check-frontend-format

--- a/dev-scripts/check-bash
+++ b/dev-scripts/check-bash
@@ -18,6 +18,4 @@ done < <(git ls-files)
 
 readonly BASH_SCRIPTS
 
-shellcheck \
-  --external-sources \
-  "${BASH_SCRIPTS[@]}"
+shellcheck "${BASH_SCRIPTS[@]}"

--- a/dev-scripts/check-bash
+++ b/dev-scripts/check-bash
@@ -8,16 +8,16 @@ set -e
 # Exit on unset variable.
 set -u
 
-readonly BASH_SCRIPTS=$(find . \
-  -not -path './\.*' \
-  -not -path './venv/*' \
-  -not -path './node_modules/*' \
-  -type f \
-  -exec bash -c 'head -n 1 {} | grep --quiet "#!/bin/bash"' \; \
-  -print)
+BASH_SCRIPTS=()
 
-shellcheck ${BASH_SCRIPTS} \
-   --exclude SC2046 \
-   --exclude SC2059 \
-   --exclude SC2156 \
-   --exclude SC2086
+while read -r line; do
+  if head -n 1 "${line}" | grep --quiet "#!/bin/bash"; then
+    BASH_SCRIPTS+=("${line}")
+  fi
+done < <(git ls-files)
+
+readonly BASH_SCRIPTS
+
+shellcheck \
+  --external-sources \
+  "${BASH_SCRIPTS[@]}"

--- a/dev-scripts/check-bash
+++ b/dev-scripts/check-bash
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Run static analysis on bash scripts.
+
+# Exit on first failing command.
+set -e
+
+# Exit on unset variable.
+set -u
+
+readonly BASH_SCRIPTS=$(find . \
+  -not -path './\.*' \
+  -not -path './venv/*' \
+  -not -path './node_modules/*' \
+  -type f \
+  -exec bash -c 'head -n 1 {} | grep --quiet "#!/bin/bash"' \; \
+  -print)
+
+shellcheck ${BASH_SCRIPTS} \
+   --exclude SC2046 \
+   --exclude SC2059 \
+   --exclude SC2156 \
+   --exclude SC2086

--- a/dev-scripts/check-trailing-newline
+++ b/dev-scripts/check-trailing-newline
@@ -7,23 +7,18 @@ set -e
 # Exit on unset variable.
 set -u
 
-readonly TEXT_FILES=$(grep \
-  ".*" \
-  --files-with-matches \
-  --binary-files=without-match \
-   --exclude="*.svg" \
-   --exclude="*third-party*" \
-   $(git ls-files | xargs)
-)
-
 success=0
 
-for text_file in ${TEXT_FILES[*]}
-do
-  if ! [[ -s "${text_file}" && -z "$(tail -c 1 "${text_file}")" ]]; then
-    printf "File must end in a trailing newline: ${text_file}\n" >&2
-    success=-1
+while read -r line; do
+  if ! [[ -s "${line}" && -z "$(tail -c 1 "${line}")" ]]; then
+    printf "File must end in a trailing newline: %s\n" "${line}" >&2
+    success=255
   fi
-done
+done < <(git ls-files \
+  | xargs grep ".*" \
+    --files-with-matches \
+    --binary-files=without-match \
+    --exclude="*.svg" \
+    --exclude="*third-party*")
 
 exit "${success}"

--- a/dev-scripts/check-trailing-whitespace
+++ b/dev-scripts/check-trailing-whitespace
@@ -7,12 +7,15 @@ set -e
 # Exit on unset variable.
 set -u
 
-if grep \
-  "\s$" \
-  --line-number \
-  --binary-files=without-match \
-  --exclude="*third-party*" \
-  $(git ls-files | xargs); then
-  echo "ERROR: Found trailing whitespace";
-  exit 1;
-fi
+while read -r line; do
+  if grep \
+    "\s$" \
+    --line-number \
+    --with-filename \
+    --binary-files=without-match \
+    --exclude="*third-party*" \
+    "${line}"; then
+    echo "ERROR: Found trailing whitespace";
+    exit 1;
+  fi
+done < <(git ls-files)

--- a/e2e/docker-test
+++ b/e2e/docker-test
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 # Echo commands to stdout.
 set -x

--- a/e2e/test
+++ b/e2e/test
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 # Echo commands to stdout.
 set -x

--- a/quick-install
+++ b/quick-install
@@ -119,6 +119,7 @@ sudo chown "$(whoami):$(whoami)" --recursive "$INSTALLER_DIR"
 pushd "$INSTALLER_DIR"
 
 python3 -m venv venv
+# shellcheck disable=SC1091
 . venv/bin/activate
 # For some reason, wheel has to be installed before anything else.
 pip install wheel==0.34.2

--- a/quick-install
+++ b/quick-install
@@ -119,7 +119,6 @@ sudo chown "$(whoami):$(whoami)" --recursive "$INSTALLER_DIR"
 pushd "$INSTALLER_DIR"
 
 python3 -m venv venv
-# shellcheck disable=SC1091
 . venv/bin/activate
 # For some reason, wheel has to be installed before anything else.
 pip install wheel==0.34.2

--- a/quick-install
+++ b/quick-install
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 # Echo commands to stdout.
 set -x
@@ -69,7 +69,7 @@ readonly EXTRA_VARS_PATH
 # Check if the user is accidentally downgrading from TinyPilot Pro.
 HAS_PRO_INSTALLED=0
 
-SCRIPT_DIR="$(dirname $0)"
+SCRIPT_DIR="$(dirname "$0")"
 # If they're piping this script in from stdin, guess that TinyPilot is
 # in the default location.
 if [ "$SCRIPT_DIR" = "." ]; then
@@ -101,7 +101,7 @@ if [ "$HAS_PRO_INSTALLED" = 1 ]; then
     printf "type the following:\n\n"
     printf "  export FORCE_DOWNGRADE=1\n\n"
     printf "And then run your previous command again.\n"
-    exit -1
+    exit 255
   fi
 fi
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 # The canonical way to update is through the update script below,
 # but this file is here for backwards compatibility.


### PR DESCRIPTION
Added a script to find all the bash scripts in this project and run static analysis on them.
Added that script as a Circle CI job.

# Design Decisions

## ShellCheck

I excluded all the problems that ShellCheck picked up in this project (by excluding them in command-line arguments).
1. I wasn't sure if it's something we would like to fix in this PR.
2. I'm not sure each "problem" is worth fixing as it would expand nifty one-liners into multiple lines. A decision needs to be made on which error codes we care about. Here are the list of issues that it picked up: 
    ```bash
    In ./dev-scripts/check-trailing-whitespace line 15:
      $(git ls-files | xargs); then
      ^---------------------^ SC2046: Quote this to prevent word splitting.
    
    
    In ./dev-scripts/check-bash line 16:
      -exec bash -c 'head -n 1 {} | grep --quiet "#!/bin/bash"' \; \
                    ^-- SC2156: Injecting filenames is fragile and insecure. Use parameters.
    
    
    In ./dev-scripts/check-bash line 19:
    shellcheck ${BASH_SCRIPTS}
               ^-------------^ SC2086: Double quote to prevent globbing and word splitting.
    
    Did you mean:
    shellcheck "${BASH_SCRIPTS}"
    
    
    In ./dev-scripts/check-trailing-newline line 16:
       $(git ls-files | xargs)
       ^---------------------^ SC2046: Quote this to prevent word splitting.
    
    
    In ./dev-scripts/check-trailing-newline line 24:
        printf "File must end in a trailing newline: ${text_file}\n" >&2
               ^-- SC2059: Don't use variables in the printf format string. Use printf '..%s..' "$foo".
    
    For more information:
      https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
      https://www.shellcheck.net/wiki/SC2156 -- Injecting filenames is fragile an...
      https://www.shellcheck.net/wiki/SC2059 -- Don't use variables in the printf...
    ```

## Finding bash scripts

Following your feedback on the issue [here](https://github.com/mtlynch/tinypilot/issues/439#issuecomment-779234930), I was having trouble using `head` together with `grep` because I was losing the filenames after executing `head`. [GNU `head`](https://man7.org/linux/man-pages/man1/head.1.html) does have a `--verbose` flag to always output filenames, but [MacOS `head`](https://ss64.com/osx/head.html) does not 😞. I ended up just letting `find` invoke the `bash` command once per file found 😬.

---

Fixes #439

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mtlynch/tinypilot/569)
<!-- Reviewable:end -->
