### PR TITLE
Introduce status bar at the bottom

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -27,7 +27,7 @@
   --brand-green-light: hsl(var(--brand-hue-green), 42%, 73%);
   --brand-green-bright: hsl(var(--brand-hue-green), 70%, 45%);
 
-  --z-index-menubar: 1;
+  --z-index-bar: 1;
   --z-index-overlay: 2;
 }
 
@@ -50,14 +50,14 @@ body {
   position: fixed;
   top: 0;
   width: 100%;
-  z-index: var(--z-index-menubar);
+  z-index: var(--z-index-bar);
 }
 
 .footer-bar {
   position: fixed;
   bottom: 0;
   width: 100%;
-  z-index: var(--z-index-menubar);
+  z-index: var(--z-index-bar);
 }
 
 html {

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -10,7 +10,7 @@
   --brand-hue-green: 135;
 
   --brand-metallic-dark: hsl(var(--brand-hue-blue), 33%, 33%);
-  --brand-metallic-medium: hsl(var(--brand-hue-metallic), 19%, 40%);
+  --brand-metallic-medium: hsl(var(--brand-hue-metallic), 18%, 45%);
   --brand-metallic-light: hsl(var(--brand-hue-metallic), 16%, 55%);
   --brand-metallic-bright: hsl(var(--brand-hue-metallic), 18%, 71%);
 
@@ -43,10 +43,19 @@ body {
   text-align: center;
   margin: 0 auto;
   padding-top: 55px; /* Account for menu bar plus some extra spacing */
+  padding-bottom: 40px; /* Account for status bar plus some extra spacing */
 }
 
 .header-bar {
   position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: var(--z-index-menubar);
+}
+
+.footer-bar {
+  position: fixed;
+  bottom: 0;
   width: 100%;
   z-index: var(--z-index-menubar);
 }

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -107,7 +107,7 @@ function onSocketConnect() {
   }
 
   connectedToServer = true;
-  document.getElementById("menu-bar").connectionIndicator.connected = true;
+  document.getElementById("status-bar").connectionIndicator.connected = true;
   setCursor(settings.getScreenCursor());
 
   // If we're restarting after an update, mark the update as finished.
@@ -120,7 +120,7 @@ function onSocketConnect() {
 function onSocketDisconnect(reason) {
   setCursor("disabled", false);
   connectedToServer = false;
-  const connectionIndicator = document.getElementById("menu-bar")
+  const connectionIndicator = document.getElementById("status-bar")
     .connectionIndicator;
   connectionIndicator.connected = false;
   connectionIndicator.disconnectReason = reason;

--- a/app/templates/custom-elements/connection-indicator.html
+++ b/app/templates/custom-elements/connection-indicator.html
@@ -15,7 +15,7 @@
     .status-dot {
       height: 1rem;
       width: 1rem;
-      margin: 0 0 0.1rem 0.6rem;
+      margin: 0 0.5rem 0.2rem 0;
       border-radius: 50%;
       display: inline-block;
       /* Disconnected state */
@@ -43,7 +43,6 @@
     }
   </style>
   <div class="status">
-    <div>Connection</div>
     <content-tooltip position="bottom">
       <span class="status-dot"></span>
       <div slot="text" class="connected-text">
@@ -54,6 +53,7 @@
         <span id="disconnect-reason"></span>
       </div>
     </content-tooltip>
+    <div>Connection</div>
   </div>
 </template>
 

--- a/app/templates/custom-elements/connection-indicator.html
+++ b/app/templates/custom-elements/connection-indicator.html
@@ -43,7 +43,7 @@
     }
   </style>
   <div class="status">
-    <content-tooltip position="bottom">
+    <content-tooltip position="top-right">
       <span class="status-dot"></span>
       <div slot="text" class="connected-text">
         You are connected to TinyPilot.

--- a/app/templates/custom-elements/content-tooltip.html
+++ b/app/templates/custom-elements/content-tooltip.html
@@ -17,17 +17,21 @@
       z-index: 1;
     }
 
-    :host([position="top-left"]) .tooltip-text {
-      width: 400px;
+    :host .tooltip-text {
+      --width: 200px;
+    }
+
+    :host([position="top-right"]) .tooltip-text {
+      width: var(--width);
       bottom: 100%;
-      left: 0%;
-      margin-left: -420px;
+      right: 0;
+      margin-right: calc(-1 * var(--width));
     }
 
     :host([position="bottom"]) .tooltip-text {
       top: 100%;
       left: 50%;
-      margin-left: -200px;
+      margin-left: calc(-1 * var(--width));
     }
 
     :host(:hover) .tooltip-text {

--- a/app/templates/custom-elements/content-tooltip.html
+++ b/app/templates/custom-elements/content-tooltip.html
@@ -1,6 +1,8 @@
 <template id="content-tooltip-template">
   <style>
     :host {
+      --tooltip-width: 200px;
+
       position: relative;
       display: inline-block;
     }
@@ -17,21 +19,17 @@
       z-index: 1;
     }
 
-    :host .tooltip-text {
-      --width: 200px;
-    }
-
     :host([position="top-right"]) .tooltip-text {
-      width: var(--width);
+      width: var(--tooltip-width);
       bottom: 100%;
       right: 0;
-      margin-right: calc(-1 * var(--width));
+      margin-right: calc(-1 * var(--tooltip-width));
     }
 
     :host([position="bottom"]) .tooltip-text {
       top: 100%;
       left: 50%;
-      margin-left: calc(-1 * var(--width));
+      margin-left: calc(-1 * var(--tooltip-width));
     }
 
     :host(:hover) .tooltip-text {

--- a/app/templates/custom-elements/menubar.html
+++ b/app/templates/custom-elements/menubar.html
@@ -154,11 +154,6 @@
       text-transform: capitalize;
     }
 
-    .connection-indicator {
-      margin-right: 2rem;
-      margin-left: auto;
-    }
-
     .nav-icon img {
       margin-top: 5px;
       max-height: 22px;
@@ -168,6 +163,10 @@
       content: "✓";
       position: absolute;
       right: 10px;
+    }
+
+    .spacer {
+      flex: 1;
     }
   </style>
 
@@ -221,11 +220,8 @@
       </ul>
     </li>
   </ul>
-  <div class="header-item connection-indicator">
-    <!-- The connection indicator will be moved
-      to the status bar later on -->
-    <connection-indicator id="connection-indicator"> </connection-indicator>
-  </div>
+
+  <div class="spacer"></div>
   <div class="header-item nav-icon">
     <a href="https://github.com/mtlynch/tinypilot" target="_blank">
       <img src="/img/GitHub-Mark-Light-120px-plus.png" />
@@ -320,12 +316,6 @@
               composed: true,
             })
           );
-        }
-
-        get connectionIndicator() {
-          // Just returning the element is a bit ugly of course. However,
-          // the indicator is supposed to be moved to the status bar anyway.
-          return this.shadowRoot.getElementById("connection-indicator");
         }
 
         set cursor(newCursor) {

--- a/app/templates/custom-elements/status-bar.html
+++ b/app/templates/custom-elements/status-bar.html
@@ -1,0 +1,51 @@
+<template id="status-bar-template">
+  <style>
+    @import "css/style.css";
+
+    :host {
+      display: flex;
+      height: 31px;
+      flex-direction: row;
+      align-items: center;
+      padding: 0 1.25rem;
+      color: white;
+      font-size: 0.9rem;
+      background-color: var(--brand-metallic-medium);
+      box-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
+      -webkit-touch-callout: none;
+      -webkit-user-select: none;
+      -khtml-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
+    }
+
+    .item {
+      padding-top: 3px;
+    }
+  </style>
+
+  <connection-indicator id="connection-indicator" class="item"></connection-indicator>
+</template>
+
+<script>
+  (function () {
+    const doc = (document._currentScript || document.currentScript)
+      .ownerDocument;
+    const template = doc.querySelector("#status-bar-template");
+
+    customElements.define(
+      "status-bar",
+      class extends HTMLElement {
+        connectedCallback() {
+          this.attachShadow({ mode: "open" });
+          this.shadowRoot.appendChild(template.content.cloneNode(true));
+        }
+
+        get connectionIndicator() {
+          return this.shadowRoot.getElementById("connection-indicator");
+        }
+      }
+    );
+  })();
+</script>

--- a/app/templates/custom-elements/status-bar.html
+++ b/app/templates/custom-elements/status-bar.html
@@ -25,7 +25,8 @@
     }
   </style>
 
-  <connection-indicator id="connection-indicator" class="item"></connection-indicator>
+  <connection-indicator id="connection-indicator" class="item">
+  </connection-indicator>
 </template>
 
 <script>

--- a/app/templates/custom-elements/status-bar.html
+++ b/app/templates/custom-elements/status-bar.html
@@ -25,8 +25,9 @@
     }
   </style>
 
-  <connection-indicator id="connection-indicator" class="item">
-  </connection-indicator>
+  <div class="item">
+    <connection-indicator id="connection-indicator"></connection-indicator>
+  </div>
 </template>
 
 <script>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -26,6 +26,9 @@
       <div class="header-bar">
         <menu-bar id="menu-bar"></menu-bar>
       </div>
+      <div class="footer-bar">
+        <status-bar id="status-bar"></status-bar>
+      </div>
 
       <div class="page-content container">
         <div id="error-panel">


### PR DESCRIPTION
As discussed in [the redesign proposal](https://github.com/tiny-pilot/tinypilot-pro/issues/53) this PR introduces a status bar at the bottom of the screen.

Equivalently to the menu bar, it’s also hovering on top of everything else in a fixed position. Currently it only houses the connection indicator, but it will soon also contain the indicator for user input events.

<img width="1003" alt="Screenshot 2021-03-11 at 17 48 55" src="https://user-images.githubusercontent.com/3618384/110823903-d4164f00-8292-11eb-8b33-fbe3566c0e4b.png">

## Remarks
- It’s the same question all over again how to make child components accessible in the code (in React too), i.e. whether either to just expose them directly (at the expense of violating Demeter’s law and encapsulation), or to wrap them up explicitly (at the expense of writing trivial decorator code). I eventually concluded that it’s okay to expose the connection indicator to the outside of the status bar, since I think of the status bar as a mere container without much logic on its own.