### PR TITLE
Display device hostname in page title

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>TinyPilot</title>
+    <title>
+      {% if hostname and hostname.lower() != 'tinypilot' %}{{ hostname }} - {%
+      endif %}TinyPilot
+    </title>
     <link rel="stylesheet" type="text/css" href="/css/style.css" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />

--- a/app/views.py
+++ b/app/views.py
@@ -1,5 +1,6 @@
 import flask
 
+import hostname
 from find_files import find as find_files
 
 views_blueprint = flask.Blueprint('views', __name__, url_prefix='')
@@ -8,7 +9,9 @@ views_blueprint = flask.Blueprint('views', __name__, url_prefix='')
 @views_blueprint.route('/', methods=['GET'])
 def index_get():
     return flask.render_template(
-        'index.html', custom_elements_files=find_files.custom_elements_files())
+        'index.html',
+        hostname=hostname.determine(),
+        custom_elements_files=find_files.custom_elements_files())
 
 
 # The style guide is for development purpose only, so we don’t ship it to


### PR DESCRIPTION
This helps the user identify the TinyPilot window if they have multiple TinyPilot devices.

Fixes #577