### PR TITLE
Introduce custom (reusable) overlay component

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -89,18 +89,3 @@ img {
 .question-icon {
   max-width: 20px;
 }
-
-#error-panel {
-  display: none;
-  /* TODO(jotaen) The hard-coded colour value will be removed once we
-      finished migrating to the “new” error overlay. */
-  background-color: hsl(var(--brand-hue-red), 52%, 80%);
-  border: 2px solid var(--brand-red);
-  max-width: 800px;
-  padding: 1rem 3rem;
-  margin: 0 auto 1rem auto;
-}
-
-#error-panel #error-type {
-  margin-top: 0;
-}

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -20,7 +20,7 @@
   --brand-blue: hsl(var(--brand-hue-blue), 80%, 60%);
 
   --brand-red: hsl(var(--brand-hue-red), 55%, 40%);
-  --brand-red-light: hsl(var(--brand-hue-red), 52%, 80%);
+  --brand-red-light: hsl(var(--brand-hue-red), 54%, 95%);
   --brand-red-bright: hsl(var(--brand-hue-red), 85%, 46%);
 
   --brand-green: hsl(var(--brand-hue-green), 40%, 45%);
@@ -92,7 +92,9 @@ img {
 
 #error-panel {
   display: none;
-  background-color: var(--brand-red-light);
+  /* TODO(jotaen) The hard-coded colour value will be removed once we
+      finished migrating to the “new” error overlay. */
+  background-color: hsl(var(--brand-hue-red), 52%, 80%);
   border: 2px solid var(--brand-red);
   max-width: 800px;
   padding: 1rem 3rem;

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -32,10 +32,8 @@ function isElementShown(id) {
 }
 
 function showError(title, message, details) {
-  document.getElementById("error-dialog")
-    .setup(title, message, details);
-  document.getElementById("error-overlay")
-    .show();
+  document.getElementById("error-dialog").setup(title, message, details);
+  document.getElementById("error-overlay").show();
 }
 
 function isKeyPressed(code) {
@@ -362,10 +360,7 @@ document
 const shutdownDialog = document.getElementById("shutdown-dialog");
 shutdownDialog.addEventListener("shutdown-started", (evt) => {
   // Hide the interactive elements of the page during shutdown.
-  for (const elementId of [
-    "remote-screen",
-    "on-screen-keyboard",
-  ]) {
+  for (const elementId of ["remote-screen", "on-screen-keyboard"]) {
     hideElementById(elementId);
   }
 });

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -31,10 +31,11 @@ function isElementShown(id) {
   return document.getElementById(id).style.display !== "none";
 }
 
-function showError(errorType, errorMessage) {
-  document.getElementById("error-type").innerText = errorType;
-  document.getElementById("error-message").innerText = errorMessage;
-  showElementById("error-panel");
+function showError(title, message, details) {
+  document.getElementById("error-dialog")
+    .setup(title, message, details);
+  document.getElementById("error-overlay")
+    .show();
 }
 
 function isKeyPressed(code) {
@@ -336,9 +337,7 @@ document
       evt.detail.horizontalWheelDelta
     );
   });
-document.getElementById("hide-error-btn").addEventListener("click", () => {
-  hideElementById("error-panel");
-});
+
 for (const button of document.getElementsByClassName("manual-modifier-btn")) {
   button.addEventListener("click", onManualModifierButtonClicked);
 }
@@ -364,7 +363,6 @@ const shutdownDialog = document.getElementById("shutdown-dialog");
 shutdownDialog.addEventListener("shutdown-started", (evt) => {
   // Hide the interactive elements of the page during shutdown.
   for (const elementId of [
-    "error-panel",
     "remote-screen",
     "on-screen-keyboard",
   ]) {

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -8,12 +8,16 @@ import {
 } from "./keycodes.js";
 import { sendKeystroke } from "./keystrokes.js";
 import * as settings from "./settings.js";
+import { OverlayTracker } from "./overlays.js";
 
 const socket = io();
 let connectedToServer = false;
 
 // A map of keycodes to booleans indicating whether the key is currently pressed.
 let keyState = {};
+
+// Keep track of overlays, in order to properly deactivate keypress forwarding.
+const overlayTracker = new OverlayTracker();
 
 function hideElementById(id) {
   document.getElementById(id).style.display = "none";
@@ -125,7 +129,7 @@ function onSocketDisconnect(reason) {
 }
 
 function onKeyDown(evt) {
-  if (isPasteOverlayShowing()) {
+  if (isPasteOverlayShowing() || overlayTracker.hasOverlays()) {
     return;
   }
 
@@ -279,6 +283,9 @@ document.onload = document.getElementById("app").focus();
 
 document.addEventListener("keydown", onKeyDown);
 document.addEventListener("keyup", onKeyUp);
+document.addEventListener("overlay-toggled", (evt) => {
+  overlayTracker.trackStatus(evt.target, evt.detail.isShown);
+});
 
 const menuBar = document.getElementById("menu-bar");
 menuBar.cursor = settings.getScreenCursor();

--- a/app/static/js/overlays.js
+++ b/app/static/js/overlays.js
@@ -1,3 +1,8 @@
+/**
+ * A registry to keep track of all overlays being shown.
+ * Usually, there should be just one overlay at any time, but technically
+ * speaking it’s not safe to rely on that.
+ */
 export class OverlayTracker {
   currentOverlays = new Set();
 

--- a/app/static/js/overlays.js
+++ b/app/static/js/overlays.js
@@ -1,0 +1,15 @@
+export class OverlayTracker {
+  currentOverlays = new Set();
+
+  hasOverlays() {
+    return this.currentOverlays.size > 0;
+  }
+
+  trackStatus(overlayElement, isShown) {
+    if (isShown) {
+      this.currentOverlays.add(overlayElement);
+    } else {
+      this.currentOverlays.delete(overlayElement);
+    }
+  }
+}

--- a/app/static/js/paste.js
+++ b/app/static/js/paste.js
@@ -5,6 +5,7 @@ pasteOverlay.addEventListener("click", () => {
   hidePasteOverlay();
 });
 
+// TODO(jotaen) Migrate this to use `OverlayTracker`
 function isPasteOverlayShowing() {
   return pasteOverlay.getAttribute("show") === "true";
 }

--- a/app/templates/custom-elements/error-dialog.html
+++ b/app/templates/custom-elements/error-dialog.html
@@ -26,7 +26,7 @@
   <p id="message"></p>
   <div id="details-container">
     <div class="details-label">Details:</div>
-    <div id="details" class="monospace"></div>
+    <pre id="details" class="monospace"></pre>
   </div>
   <button id="close">Close</button>
 </template>

--- a/app/templates/custom-elements/error-dialog.html
+++ b/app/templates/custom-elements/error-dialog.html
@@ -43,7 +43,16 @@
         connectedCallback() {
           this.attachShadow({ mode: "open" });
           this.shadowRoot.appendChild(template.content.cloneNode(true));
-          this.shadowRoot.getElementById("close").onclick = this.close;
+          this.close = this.close.bind(this);
+          this.shadowRoot
+            .getElementById("close")
+            .addEventListener("click", this.close);
+        }
+
+        disconnectedCallback() {
+          this.shadowRoot
+            .getElementById("close")
+            .removeEventListener("click", this.close);
         }
 
         /**

--- a/app/templates/custom-elements/error-dialog.html
+++ b/app/templates/custom-elements/error-dialog.html
@@ -1,0 +1,73 @@
+<template id="error-dialog-template">
+  <style>
+    @import "css/style.css";
+
+    #details {
+      padding: 0.5rem;
+      max-height: 50vh;
+      overflow: scroll;
+      opacity: 0.7;
+      border: 1px solid black;
+      background-color: white;
+      text-align: left;
+      font-size: 0.8em;
+    }
+
+    .details-label {
+      color: var(--brand-red);
+      font-weight: 600;
+      text-align: left;
+      font-size: 0.9em;
+      margin: 0.25rem 0.4rem;
+    }
+  </style>
+
+  <h3 id="title"></h3>
+  <p id="message"></p>
+  <div id="details-container">
+    <div class="details-label">Details:</div>
+    <div id="details" class="monospace"></div>
+  </div>
+  <button id="close">Close</button>
+</template>
+
+<script>
+  (function () {
+    const doc = (document._currentScript || document.currentScript)
+      .ownerDocument;
+    const template = doc.querySelector("#error-dialog-template");
+
+    customElements.define(
+      "error-dialog",
+      class extends HTMLElement {
+        connectedCallback() {
+          this.attachShadow({ mode: "open" });
+          this.shadowRoot.appendChild(template.content.cloneNode(true));
+          this.shadowRoot.getElementById("close").onclick = this.close;
+        }
+
+        /**
+         * @param title   A concise summary of the error.
+         * @param message A user-friendly and helpful message that (ideally)
+         *                gives the user some guidance what to do now.
+         * @param details (optional) The technical error details, e.g. the
+         *                original error message from the API or library call.
+         */
+        setup(title, message, details = "") {
+          this.shadowRoot.getElementById("title").innerText = title;
+          this.shadowRoot.getElementById("message").innerText = message;
+          this.shadowRoot.getElementById("details").innerText = details;
+          this.shadowRoot.getElementById("details-container")
+            .style.display = details ? "block" : "none";
+        }
+
+        close() {
+          this.dispatchEvent(new CustomEvent("dialog-closed", {
+            bubbles: true,
+            composed: true,
+          }));
+        }
+      }
+    );
+  })();
+</script>

--- a/app/templates/custom-elements/error-dialog.html
+++ b/app/templates/custom-elements/error-dialog.html
@@ -49,12 +49,6 @@
             .addEventListener("click", this.close);
         }
 
-        disconnectedCallback() {
-          this.shadowRoot
-            .getElementById("close")
-            .removeEventListener("click", this.close);
-        }
-
         /**
          * @param title   A concise summary of the error.
          * @param message A user-friendly and helpful message that (ideally)

--- a/app/templates/custom-elements/error-dialog.html
+++ b/app/templates/custom-elements/error-dialog.html
@@ -57,15 +57,18 @@
           this.shadowRoot.getElementById("title").innerText = title;
           this.shadowRoot.getElementById("message").innerText = message;
           this.shadowRoot.getElementById("details").innerText = details;
-          this.shadowRoot.getElementById("details-container")
-            .style.display = details ? "block" : "none";
+          this.shadowRoot.getElementById(
+            "details-container"
+          ).style.display = details ? "block" : "none";
         }
 
         close() {
-          this.dispatchEvent(new CustomEvent("dialog-closed", {
-            bubbles: true,
-            composed: true,
-          }));
+          this.dispatchEvent(
+            new CustomEvent("dialog-closed", {
+              bubbles: true,
+              composed: true,
+            })
+          );
         }
       }
     );

--- a/app/templates/custom-elements/overlay-panel.html
+++ b/app/templates/custom-elements/overlay-panel.html
@@ -28,7 +28,7 @@
       text-align: center;
     }
 
-    :host([variant="error"]) .panel {
+    :host([variant="danger"]) .panel {
       border-top: 0.4rem solid var(--brand-red-bright);
       background-color: var(--brand-red-light);
     }

--- a/app/templates/custom-elements/overlay-panel.html
+++ b/app/templates/custom-elements/overlay-panel.html
@@ -12,7 +12,7 @@
       left: 0;
       right: 0;
       bottom: 0;
-      background-color: rgba(0, 0, 0, 0.75);
+      background-color: rgba(0, 0, 0, 0.7);
       z-index: var(--z-index-overlay);
     }
 
@@ -20,15 +20,21 @@
       display: block;
     }
 
-    .panel {
-      background-color: var(--brand-creme-light);
+    #panel {
       max-width: 800px;
       margin: 100px auto;
       padding: 2rem;
       text-align: center;
     }
 
-    :host([variant="danger"]) .panel {
+    :host([variant="default"]) #panel,
+    :host([variant=""]) #panel,
+    :host(:not([variant])) #panel {
+      border-top: none;
+      background-color: var(--brand-creme-light);
+    }
+
+    :host([variant="danger"]) #panel {
       border-top: 0.4rem solid var(--brand-red-bright);
       background-color: var(--brand-red-light);
     }
@@ -65,8 +71,6 @@
           this.setAttribute("show", newValue);
         }
 
-        set variant(newValue) {
-          this.setAttribute("variant", newValue);
         }
       }
     );

--- a/app/templates/custom-elements/overlay-panel.html
+++ b/app/templates/custom-elements/overlay-panel.html
@@ -68,11 +68,13 @@
 
         show(isShown = true) {
           this.setAttribute("show", isShown ? "true" : "false");
-          this.dispatchEvent(new CustomEvent("overlay-toggled", {
-            detail: { isShown },
-            bubbles: true,
-            composed: true,
-          }));
+          this.dispatchEvent(
+            new CustomEvent("overlay-toggled", {
+              detail: { isShown },
+              bubbles: true,
+              composed: true,
+            })
+          );
         }
 
         hide() {

--- a/app/templates/custom-elements/overlay-panel.html
+++ b/app/templates/custom-elements/overlay-panel.html
@@ -35,7 +35,7 @@
   </style>
 
   <div class="panel neutral">
-    <slot name="panel"></slot>
+    <slot></slot>
   </div>
 </template>
 

--- a/app/templates/custom-elements/overlay-panel.html
+++ b/app/templates/custom-elements/overlay-panel.html
@@ -54,23 +54,29 @@
     customElements.define(
       "overlay-panel",
       class extends HTMLElement {
-        constructor() {
-          super();
-        }
-
         connectedCallback() {
           this.attachShadow({ mode: "open" });
           this.shadowRoot.appendChild(template.content.cloneNode(true));
+          this.hide = this.hide.bind(this);
+          this.show = this.show.bind(this);
+          this.shadowRoot.addEventListener("dialog-closed", this.hide);
         }
 
-        get show() {
-          return this.getAttribute("show") === "true";
+        disconnectedCallback() {
+          this.shadowRoot.removeEventListener("dialog-closed", this.hide);
         }
 
-        set show(newValue) {
-          this.setAttribute("show", newValue);
+        show(isShown = true) {
+          this.setAttribute("show", isShown ? "true" : "false");
+          this.dispatchEvent(new CustomEvent("overlay-toggled", {
+            detail: { isShown },
+            bubbles: true,
+            composed: true,
+          }));
         }
 
+        hide() {
+          this.show(false);
         }
       }
     );

--- a/app/templates/custom-elements/overlay-panel.html
+++ b/app/templates/custom-elements/overlay-panel.html
@@ -1,0 +1,74 @@
+<template id="overlay-panel-template">
+  <style>
+    @import "css/style.css";
+
+    :host {
+      display: none;
+      position: fixed;
+      overflow: scroll;
+      width: 100%;
+      height: 100%;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background-color: rgba(0, 0, 0, 0.75);
+      z-index: var(--z-index-overlay);
+    }
+
+    :host([show="true"]) {
+      display: block;
+    }
+
+    .panel {
+      background-color: var(--brand-creme-light);
+      max-width: 800px;
+      margin: 100px auto;
+      padding: 2rem;
+      text-align: center;
+    }
+
+    :host([variant="error"]) .panel {
+      border-top: 0.4rem solid var(--brand-red-bright);
+      background-color: var(--brand-red-light);
+    }
+  </style>
+
+  <div class="panel neutral">
+    <slot name="panel"></slot>
+  </div>
+</template>
+
+<script>
+  (function () {
+    const doc = (document._currentScript || document.currentScript)
+      .ownerDocument;
+    const template = doc.querySelector("#overlay-panel-template");
+
+    customElements.define(
+      "overlay-panel",
+      class extends HTMLElement {
+        constructor() {
+          super();
+        }
+
+        connectedCallback() {
+          this.attachShadow({ mode: "open" });
+          this.shadowRoot.appendChild(template.content.cloneNode(true));
+        }
+
+        get show() {
+          return this.getAttribute("show") === "true";
+        }
+
+        set show(newValue) {
+          this.setAttribute("show", newValue);
+        }
+
+        set variant(newValue) {
+          this.setAttribute("variant", newValue);
+        }
+      }
+    );
+  })();
+</script>

--- a/app/templates/custom-elements/overlay-panel.html
+++ b/app/templates/custom-elements/overlay-panel.html
@@ -57,13 +57,10 @@
         connectedCallback() {
           this.attachShadow({ mode: "open" });
           this.shadowRoot.appendChild(template.content.cloneNode(true));
-          this.hide = this.hide.bind(this);
           this.show = this.show.bind(this);
-          this.shadowRoot.addEventListener("dialog-closed", this.hide);
-        }
-
-        disconnectedCallback() {
-          this.shadowRoot.removeEventListener("dialog-closed", this.hide);
+          this.shadowRoot.addEventListener("dialog-closed", () =>
+            this.show(false)
+          );
         }
 
         show(isShown = true) {
@@ -75,10 +72,6 @@
               composed: true,
             })
           );
-        }
-
-        hide() {
-          this.show(false);
         }
       }
     );

--- a/app/templates/custom-elements/overlay-panel.html
+++ b/app/templates/custom-elements/overlay-panel.html
@@ -34,7 +34,7 @@
     }
   </style>
 
-  <div class="panel neutral">
+  <div id="panel">
     <slot></slot>
   </div>
 </template>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -29,12 +29,9 @@
       </div>
 
       <div class="page-content container">
-        <div id="error-panel">
-          <h3 id="error-type">Error Type</h3>
-          <p id="error-message">Error message</p>
-          <button id="hide-error-btn" type="button">Close</button>
-        </div>
-
+        <overlay-panel id="error-overlay" variant="danger">
+          <error-dialog id="error-dialog"></error-dialog>
+        </overlay-panel>
         <shutdown-dialog id="shutdown-dialog"></shutdown-dialog>
         <update-dialog id="update-dialog"></update-dialog>
         <change-hostname-dialog

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -23,9 +23,8 @@
     }
   </style>
   <body>
-    {% for child_template in custom_elements_files %}
-      {% include child_template.replace('./app/templates/', '') %}
-    {% endfor %}
+    {% for child_template in custom_elements_files %} {% include
+    child_template.replace('./app/templates/', '') %} {% endfor %}
     <main>
       <div
         style="
@@ -89,16 +88,9 @@
           style="background-color: var(--brand-sand-light);"
         ></div>
       </div>
-      <div style="clear: both"></div>
+      <div style="clear: both;"></div>
 
       <h3>Overlay</h3>
-      <script>
-        function openOverlay(variant = "") {
-          const overlay = document.getElementById('example-overlay');
-          overlay.variant = variant;
-          overlay.show = true;
-        }
-      </script>
       <button onClick="openOverlay()">Regular</button>
       <button onClick="openOverlay('error')">Error</button>
       <overlay-panel id="example-overlay">
@@ -107,17 +99,27 @@
           <p>
             Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam
             nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam
-            erat, sed diam voluptua. At vero eos et accusam et justo duo
-            dolores et ea rebum. Stet clita kasd gubergren, no sea takimata
-            sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
-            consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt
-            ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero
-            eos et accusam et justo duo dolores et ea rebum. Stet clita kasd
-            gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+            erat, sed diam voluptua. At vero eos et accusam et justo duo dolores
+            et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est
+            Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur
+            sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore
+            et dolore magna aliquyam erat, sed diam voluptua. At vero eos et
+            accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
+            no sea takimata sanctus est Lorem ipsum dolor sit amet.
           </p>
-          <button onClick="document.getElementById('example-overlay').show=false">Close</button>
+          <button onClick="closeOverlay()">Close</button>
         </div>
       </overlay-panel>
+      <script>
+        const overlay = document.getElementById("example-overlay");
+        function openOverlay(variant = "") {
+          overlay.variant = variant;
+          overlay.show = true;
+        }
+        function closeOverlay() {
+          overlay.show = false;
+        }
+      </script>
     </main>
   </body>
 </html>

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -92,7 +92,7 @@
 
       <h3>Overlay</h3>
       <button onClick="openOverlay()">Regular</button>
-      <button onClick="openOverlay('error')">Error</button>
+      <button onClick="openOverlay('danger')">Error</button>
       <overlay-panel id="example-overlay">
         <div slot="panel">
           <h1>Title</h1>

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -19,6 +19,9 @@
     }
   </style>
   <body>
+    {% for child_template in custom_elements_files %}
+      {% include child_template.replace('./app/templates/', '') %}
+    {% endfor %}
     <main>
       <div
         style="

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -17,8 +17,16 @@
       height: 5rem;
       min-width: 10rem;
     }
+    h3 {
+      margin-top: 2rem;
+      margin-bottom: 1rem;
+    }
   </style>
   <body>
+    <!-- prettier-ignore -->
+    {% for child_template in custom_elements_files %}
+      {% include child_template.replace('./app/templates/', '') %}
+    {% endfor %}
     <main>
       <div
         style="
@@ -34,6 +42,7 @@
         This style guide is an ongoing collection of all things visual that make
         up the brand, such as colours, fonts, patterns or UI components.
       </p>
+      <h3>Colors</h3>
       <div>
         <div
           class="colorcard"
@@ -80,6 +89,37 @@
           style="background-color: var(--brand-sand-light);"
         ></div>
       </div>
+
+      <div style="clear: both;"></div>
+
+      <h3>Overlay</h3>
+
+      <overlay-panel id="error-overlay" variant="danger">
+        <error-dialog id="error-dialog"></error-dialog>
+      </overlay-panel>
+      <button id="show-error-btn" class="btn-danger">Error</button>
+      <script>
+        console.log(document.getElementById("error-dialog"));
+        console.log(document.getElementById("error-dialog").setup);
+        document
+          .getElementById("show-error-btn")
+          .addEventListener("click", () => {
+            document
+              .getElementById("error-dialog")
+              .setup(
+                "Example Error Message",
+                "Your style guide is showing you an example error. " +
+                  "Please reload the page.",
+                "" +
+                  "dummyElementFailed: line 502\n" +
+                  "  dummyParentElement returned unexpected response: foo\n" +
+                  "    exhausted resources.\n" +
+                  "Stacktrace:\n" +
+                  "  fooBarBaz\n".repeat(80)
+              );
+            document.getElementById("error-overlay").show();
+          });
+      </script>
     </main>
   </body>
 </html>

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -17,10 +17,6 @@
       height: 5rem;
       min-width: 10rem;
     }
-    h3 {
-      margin-top: 2rem;
-      margin-bottom: 1rem;
-    }
   </style>
   <body>
     <main>
@@ -38,8 +34,6 @@
         This style guide is an ongoing collection of all things visual that make
         up the brand, such as colours, fonts, patterns or UI components.
       </p>
-
-      <h3>Colors</h3>
       <div>
         <div
           class="colorcard"

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -23,8 +23,6 @@
     }
   </style>
   <body>
-    {% for child_template in custom_elements_files %} {% include
-    child_template.replace('./app/templates/', '') %} {% endfor %}
     <main>
       <div
         style="
@@ -88,36 +86,6 @@
           style="background-color: var(--brand-sand-light);"
         ></div>
       </div>
-      <div style="clear: both;"></div>
-
-      <h3>Overlay</h3>
-      <button onClick="openOverlay()">Regular</button>
-      <button onClick="openOverlay('danger')">Error</button>
-      <overlay-panel id="example-overlay">
-        <h1>Title</h1>
-        <p>
-          Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam
-          nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat,
-          sed diam voluptua. At vero eos et accusam et justo duo dolores et ea
-          rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem
-          ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur
-          sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
-          dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam
-          et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
-          takimata sanctus est Lorem ipsum dolor sit amet.
-        </p>
-        <button onClick="closeOverlay()">Close</button>
-      </overlay-panel>
-      <script>
-        const overlay = document.getElementById("example-overlay");
-        function openOverlay(variant = "") {
-          overlay.variant = variant;
-          overlay.show = true;
-        }
-        function closeOverlay() {
-          overlay.show = false;
-        }
-      </script>
     </main>
   </body>
 </html>

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -17,6 +17,10 @@
       height: 5rem;
       min-width: 10rem;
     }
+    h3 {
+      margin-top: 2rem;
+      margin-bottom: 1rem;
+    }
   </style>
   <body>
     {% for child_template in custom_elements_files %}
@@ -37,6 +41,8 @@
         This style guide is an ongoing collection of all things visual that make
         up the brand, such as colours, fonts, patterns or UI components.
       </p>
+
+      <h3>Colors</h3>
       <div>
         <div
           class="colorcard"
@@ -83,6 +89,35 @@
           style="background-color: var(--brand-sand-light);"
         ></div>
       </div>
+      <div style="clear: both"></div>
+
+      <h3>Overlay</h3>
+      <script>
+        function openOverlay(variant = "") {
+          const overlay = document.getElementById('example-overlay');
+          overlay.variant = variant;
+          overlay.show = true;
+        }
+      </script>
+      <button onClick="openOverlay()">Regular</button>
+      <button onClick="openOverlay('error')">Error</button>
+      <overlay-panel id="example-overlay">
+        <div slot="panel">
+          <h1>Title</h1>
+          <p>
+            Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam
+            nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam
+            erat, sed diam voluptua. At vero eos et accusam et justo duo
+            dolores et ea rebum. Stet clita kasd gubergren, no sea takimata
+            sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+            consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt
+            ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero
+            eos et accusam et justo duo dolores et ea rebum. Stet clita kasd
+            gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+          </p>
+          <button onClick="document.getElementById('example-overlay').show=false">Close</button>
+        </div>
+      </overlay-panel>
     </main>
   </body>
 </html>

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -94,21 +94,19 @@
       <button onClick="openOverlay()">Regular</button>
       <button onClick="openOverlay('danger')">Error</button>
       <overlay-panel id="example-overlay">
-        <div slot="panel">
-          <h1>Title</h1>
-          <p>
-            Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam
-            nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam
-            erat, sed diam voluptua. At vero eos et accusam et justo duo dolores
-            et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est
-            Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur
-            sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore
-            et dolore magna aliquyam erat, sed diam voluptua. At vero eos et
-            accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
-            no sea takimata sanctus est Lorem ipsum dolor sit amet.
-          </p>
-          <button onClick="closeOverlay()">Close</button>
-        </div>
+        <h1>Title</h1>
+        <p>
+          Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam
+          nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat,
+          sed diam voluptua. At vero eos et accusam et justo duo dolores et ea
+          rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem
+          ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur
+          sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+          dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam
+          et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+          takimata sanctus est Lorem ipsum dolor sit amet.
+        </p>
+        <button onClick="closeOverlay()">Close</button>
       </overlay-panel>
       <script>
         const overlay = document.getElementById("example-overlay");

--- a/app/views.py
+++ b/app/views.py
@@ -19,7 +19,9 @@ def index_get():
 @views_blueprint.route('/styleguide', methods=['GET'])
 def styleguide_get():
     if flask.current_app.debug:
-        return flask.render_template('styleguide.html')
+        return flask.render_template(
+            'styleguide.html',
+            custom_elements_files=find_files.custom_elements_files())
     return flask.abort(404)
 
 

--- a/app/views.py
+++ b/app/views.py
@@ -19,9 +19,7 @@ def index_get():
 @views_blueprint.route('/styleguide', methods=['GET'])
 def styleguide_get():
     if flask.current_app.debug:
-        return flask.render_template(
-            'styleguide.html',
-            custom_elements_files=find_files.custom_elements_files())
+        return flask.render_template('styleguide.html')
     return flask.abort(404)
 
 


### PR DESCRIPTION
Addresses https://github.com/mtlynch/tinypilot/issues/536 and introduces a custom overlay component that can be used for all dialog panels. The usage is demonstrated on the style guide page. I have also tested it out in the “real” app already, where it appears to work fine too.

## Remarks
- The `danger` variant already accounts for the to-be-introduced error panels, it’s basically a styling variation. (Analogous to `btn-danger`.)
- https://github.com/mtlynch/tinypilot/issues/583 is accounted for (but of course we must migrate first to close this issue).
- I deliberately did **not** take over the `user-select: none` directive that is present on the original overlays. Was there a specific reason why you did that initially?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mtlynch/tinypilot/585)
<!-- Reviewable:end -->
