### PR TITLE
Remove wildcard from CORS allowed origins.

### DIFF
--- a/app/socket_api.py
+++ b/app/socket_api.py
@@ -19,13 +19,7 @@ keyboard_path = os.environ.get('KEYBOARD_PATH', '/dev/hidg0')
 # Location of file path at which to write mouse HID input.
 mouse_path = os.environ.get('MOUSE_PATH', '/dev/hidg1')
 
-# TODO(mtlynch): Ideally, we wouldn't accept requests from any origin, but the
-# risk of a CSRF attack for this app is very low. Additionally, CORS doesn't
-# protect us from the dangerous part of a CSRF attack. Even without same-origin
-# enforcement, third-party pages can still *send* requests (i.e. inject
-# keystrokes into the target machine) - it doesn't matter much if they can't
-# read responses.
-socketio = flask_socketio.SocketIO(cors_allowed_origins='*')
+socketio = flask_socketio.SocketIO()
 
 
 @socketio.on('keystroke')


### PR DESCRIPTION
Based on the [fix applied to the nginx config](https://github.com/mtlynch/ansible-role-tinypilot/pull/113), we can now remove the wildcard from the CORS allowed origins.

Fixes #99 