### PR TITLE
Refactor shutdown dialog to use new overlay

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -101,7 +101,7 @@ function processKeystroke(keystroke) {
 }
 
 function onSocketConnect() {
-  if (document.getElementById("shutdown-dialog").show) {
+  if (document.getElementById("shutdown-overlay").isShown()) {
     location.reload();
     return;
   }
@@ -300,7 +300,7 @@ menuBar.addEventListener("keyboard-visibility-toggled", () => {
   setKeyboardVisibility(!isElementShown("on-screen-keyboard"));
 });
 menuBar.addEventListener("shutdown-dialog-requested", () => {
-  document.getElementById("shutdown-dialog").show = true;
+  document.getElementById("shutdown-overlay").show();
 });
 menuBar.addEventListener("update-dialog-requested", () => {
   const updateDialog = document.getElementById("update-dialog");
@@ -365,7 +365,6 @@ shutdownDialog.addEventListener("shutdown-started", (evt) => {
   }
 });
 shutdownDialog.addEventListener("shutdown-failure", (evt) => {
-  shutdownDialog.show = false;
   showError(evt.detail.summary, evt.detail.detail);
 });
 

--- a/app/templates/custom-elements/overlay-panel.html
+++ b/app/templates/custom-elements/overlay-panel.html
@@ -73,6 +73,10 @@
             })
           );
         }
+
+        isShown() {
+          return this.getAttribute("show") === "true";
+        }
       }
     );
   })();

--- a/app/templates/custom-elements/shutdown-dialog.html
+++ b/app/templates/custom-elements/shutdown-dialog.html
@@ -26,32 +26,34 @@
       display: block;
     }
   </style>
-  <div id="shutdown-confirmation-panel">
-    <div id="prompt">
-      <h3>Shut Down TinyPilot Device?</h3>
-      <p>
-        Note that this will shut down <strong>TinyPilot</strong>, not the
-        machine to which it is attached.
-      </p>
-      <button id="confirm-shutdown" class="btn-danger" type="button">
-        Shut Down
-      </button>
-      <button id="confirm-restart" class="btn-danger" type="button">
-        Restart
-      </button>
-      <button id="cancel-shutdown" type="button">Cancel</button>
-    </div>
-    <div id="restarting">
-      <h3>Restarting TinyPilot device</h3>
-      <progress-spinner></progress-spinner>
-    </div>
-    <div id="shutting-down">
-      <h3>Shutting down TinyPilot device</h3>
-      <progress-spinner></progress-spinner>
-    </div>
-    <div id="shutdown-complete">
-      <h3>Shutdown complete</h3>
-    </div>
+
+  <div id="prompt">
+    <h3>Shut Down TinyPilot Device?</h3>
+    <p>
+      Note that this will shut down <strong>TinyPilot</strong>, not the machine
+      to which it is attached.
+    </p>
+    <button id="confirm-shutdown" class="btn-danger" type="button">
+      Shut Down
+    </button>
+    <button id="confirm-restart" class="btn-danger" type="button">
+      Restart
+    </button>
+    <button id="cancel-shutdown" type="button">Cancel</button>
+  </div>
+
+  <div id="restarting">
+    <h3>Restarting TinyPilot device</h3>
+    <progress-spinner></progress-spinner>
+  </div>
+
+  <div id="shutting-down">
+    <h3>Shutting down TinyPilot device</h3>
+    <progress-spinner></progress-spinner>
+  </div>
+
+  <div id="shutdown-complete">
+    <h3>Shutdown complete</h3>
   </div>
 </template>
 

--- a/app/templates/custom-elements/shutdown-dialog.html
+++ b/app/templates/custom-elements/shutdown-dialog.html
@@ -77,17 +77,17 @@
           this.shadowRoot
             .getElementById("confirm-shutdown")
             .addEventListener("click", () => {
-              this.doShutdown(/*restart=*/ false);
+              this._doShutdown(/*restart=*/ false);
             });
           this.shadowRoot
             .getElementById("confirm-restart")
             .addEventListener("click", () => {
-              this.doShutdown(/*restart=*/ true);
+              this._doShutdown(/*restart=*/ true);
             });
           this.shadowRoot
             .getElementById("cancel-shutdown")
             .addEventListener("click", () => {
-              this.close();
+              this._close();
             });
         }
 
@@ -99,11 +99,11 @@
           this.setAttribute("state", newValue);
         }
 
-        doShutdown(restart) {
+        _doShutdown(restart) {
           controllers
             .shutdown(restart)
             .then(() => {
-              this.emitShutdownStartedEvent(restart);
+              this._emitShutdownStartedEvent(restart);
               if (restart) {
                 this.state = "restarting";
               } else {
@@ -117,12 +117,12 @@
             })
             .catch((error) => {
               if (restart) {
-                this.handleShutdownFailure(
+                this._handleShutdownFailure(
                   "Failed to restart TinyPilot device",
                   error
                 );
               } else {
-                this.handleShutdownFailure(
+                this._handleShutdownFailure(
                   "Failed to shut down TinyPilot device",
                   error
                 );
@@ -130,7 +130,7 @@
             });
         }
 
-        emitShutdownStartedEvent(restart) {
+        _emitShutdownStartedEvent(restart) {
           this.dispatchEvent(
             new CustomEvent("shutdown-started", {
               detail: { restart },
@@ -140,8 +140,8 @@
           );
         }
 
-        handleShutdownFailure(summary, detail) {
-          this.close();
+        _handleShutdownFailure(summary, detail) {
+          this._close();
           this.dispatchEvent(
             new CustomEvent("shutdown-failure", {
               detail: { summary, detail },
@@ -151,7 +151,7 @@
           );
         }
 
-        close() {
+        _close() {
           this.dispatchEvent(
             new CustomEvent("dialog-closed", {
               bubbles: true,

--- a/app/templates/custom-elements/shutdown-dialog.html
+++ b/app/templates/custom-elements/shutdown-dialog.html
@@ -3,29 +3,6 @@
     @import "css/style.css";
     @import "css/button.css";
 
-    .overlay {
-      display: none;
-      -webkit-touch-callout: none;
-      -webkit-user-select: none;
-      -khtml-user-select: none;
-      -moz-user-select: none;
-      -ms-user-select: none;
-      user-select: none;
-    }
-
-    :host([show="true"]) .overlay {
-      display: block;
-      position: fixed;
-      width: 100%;
-      height: 100%;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      background-color: rgba(0, 0, 0, 0.8);
-      z-index: var(--z-index-overlay);
-    }
-
     #prompt,
     #restarting,
     #shutting-down,
@@ -48,16 +25,8 @@
     :host([state="shutdown-complete"]) #shutdown-complete {
       display: block;
     }
-
-    #shutdown-confirmation-panel > div {
-      background-color: var(--brand-creme-light);
-      border: 1px solid var(--brand-metallic-dark);
-      max-width: 800px;
-      margin: 100px auto 0rem auto;
-      padding: 2rem;
-    }
   </style>
-  <div id="shutdown-confirmation-panel" class="overlay">
+  <div id="shutdown-confirmation-panel">
     <div id="prompt">
       <h3>Shut Down TinyPilot Device?</h3>
       <p>
@@ -110,7 +79,6 @@
             .addEventListener("click", () => {
               this.doShutdown(/*restart=*/ false);
             });
-
           this.shadowRoot
             .getElementById("confirm-restart")
             .addEventListener("click", () => {
@@ -119,24 +87,8 @@
           this.shadowRoot
             .getElementById("cancel-shutdown")
             .addEventListener("click", () => {
-              this.show = false;
+              this.close();
             });
-          this.shadowRoot
-            .getElementById("shutdown-confirmation-panel")
-            .addEventListener("click", (evt) => {
-              evt = window.event || evt;
-              if (evt.target.className === "overlay") {
-                this.show = false;
-              }
-            });
-        }
-
-        get show() {
-          return this.getAttribute("show") === "true";
-        }
-
-        set show(newValue) {
-          this.setAttribute("show", newValue);
         }
 
         get state() {
@@ -165,12 +117,12 @@
             })
             .catch((error) => {
               if (restart) {
-                this.emitShutdownFailureEvent(
+                this.handleShutdownFailure(
                   "Failed to restart TinyPilot device",
                   error
                 );
               } else {
-                this.emitShutdownFailureEvent(
+                this.handleShutdownFailure(
                   "Failed to shut down TinyPilot device",
                   error
                 );
@@ -188,10 +140,20 @@
           );
         }
 
-        emitShutdownFailureEvent(summary, detail) {
+        handleShutdownFailure(summary, detail) {
+          this.close();
           this.dispatchEvent(
             new CustomEvent("shutdown-failure", {
               detail: { summary, detail },
+              bubbles: true,
+              composed: true,
+            })
+          );
+        }
+
+        close() {
+          this.dispatchEvent(
+            new CustomEvent("dialog-closed", {
               bubbles: true,
               composed: true,
             })

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -32,7 +32,9 @@
         <overlay-panel id="error-overlay" variant="danger">
           <error-dialog id="error-dialog"></error-dialog>
         </overlay-panel>
-        <shutdown-dialog id="shutdown-dialog"></shutdown-dialog>
+        <overlay-panel id="shutdown-overlay">
+          <shutdown-dialog id="shutdown-dialog"></shutdown-dialog>
+        </overlay-panel>
         <update-dialog id="update-dialog"></update-dialog>
         <change-hostname-dialog
           id="change-hostname-dialog"


### PR DESCRIPTION
- Wrap up the shutdown dialog into the new generic overlay and migrate all related code
- Introduce a `isShown()` method on the overlay (since `app.js` depends on that functionality)
- Use underscore prefix to indicate private visibility of methods
- The diff in the HTML is because I stripped the obsolete enclosing `<div>` which changed the indentation level
- I had to remove the “outside” click functionality unfortunately. We can consider to bring it back to the generic overlay, although I think it’s not strictly needed.