### PR TITLE
Adjust timing of update logic

### DIFF
--- a/app/update.py
+++ b/app/update.py
@@ -34,7 +34,7 @@ UPDATE_SCRIPT_PATH = '/opt/tinypilot-privileged/update'
 # just long enough that it's the one we see right after a device reboot but not
 # so long that there's risk of it being confused with the result from a later
 # update attempt.
-_RECENT_UPDATE_THRESHOLD_SECONDS = 60 * 3
+_RECENT_UPDATE_THRESHOLD_SECONDS = 60 * 8
 _RESULT_FILE_DIR = os.path.expanduser('~/logs')
 
 # Result files are prefixed with UTC timestamps in ISO-8601 format.

--- a/scripts/update-service
+++ b/scripts/update-service
@@ -51,6 +51,8 @@ def run_update_script():
         logger.error('Update process terminated with failing exit code: %s',
                      str(e))
         result.error = 'The update failed: %s' % str(e)
+
+    result.timestamp = utc.now()
     return result
 
 


### PR DESCRIPTION
The post-update check was treating the timestamp as the update completion time, but the update writer was only updating the timestamp at update start. As a result, TinyPilot would never see updates complete if they took longer than 3 minutes because 3 mins was the cutoff.

This relaxes the cutoff to 5 + 3 = 8 minutes and also adjusts the update logic so that it refreshes the timestamp at the end of the update.