### PR TITLE
Introduce bundler for frontend assets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,17 +37,14 @@ jobs:
             pip install --requirement requirements.txt
             pip install --requirement dev_requirements.txt
             ./dev-scripts/build-python
-  format_frontend:
+  build_frontend:
     docker:
       - image: circleci/node:13.2.0-stretch
     steps:
       - checkout
       - run:
-          name: Install prettier globally
-          command: npm install prettier@2.0.5
-      - run:
-          name: Check frontend formatting
-          command: ./dev-scripts/check-frontend-format
+          name: Install dependencies and run bundler
+          command: ./dev-scripts/build-frontend
   e2e:
     machine:
       image: ubuntu-2004:202010-01
@@ -62,5 +59,5 @@ workflows:
       - check_whitespace
       - check_bash
       - build_python
-      - format_frontend
+      - build_frontend
       - e2e

--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,6 @@ venv/
 
 # Node
 node_modules
-package-lock.json
 
 # Mac OS
 *.DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ python3.7 -m venv venv && \
   . venv/bin/activate && \
   pip install --requirement requirements.txt && \
   pip install --requirement dev_requirements.txt && \
-  npm install prettier@2.0.5
+  npm install
 ```
 
 ### Run automated tests
@@ -54,9 +54,8 @@ sudo ./dev-scripts/enable-mock-scripts
 
 To run TinyPilot on a non-Pi machine, run:
 
-```bash
-./dev-scripts/serve-dev
-```
+- `./dev-scripts/serve-dev` to start the backend
+- `./dev-scripts/watch-frontend` to start the frontend bundling
 
 ## Architecture
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -58,7 +58,7 @@
     {% include "components/paste-overlay.html" %}
     <script src="/third-party/socket.io/3.1.3/socket.io.min.js"></script>
     <script src="/js/paste.js"></script>
-    <script type="module" src="/js/app.js"></script>
+    <script type="module" src="/dist/app.js"></script>
 
     <div style="opacity: 0;">
       <!-- Force browser to preload font variants in order to

--- a/dev-scripts/build
+++ b/dev-scripts/build
@@ -13,4 +13,4 @@ set -u
 ./dev-scripts/check-trailing-newline
 ./dev-scripts/check-bash
 ./dev-scripts/build-python
-./dev-scripts/check-frontend-format
+./dev-scripts/build-frontend

--- a/dev-scripts/build-frontend
+++ b/dev-scripts/build-frontend
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Exit build script on first failure.
+set -e
+
+# Echo commands to stdout.
+set -x
+
+# Exit on unset variable.
+set -u
+
+# Install dependencies.
+npm install
+
+# Make sure that frontend sources are formatted properly
+./node_modules/.bin/prettier --check app
+
+# Build/bundle frontend distributables.
+./node_modules/.bin/rollup --config

--- a/dev-scripts/watch-frontend
+++ b/dev-scripts/watch-frontend
@@ -9,4 +9,5 @@ set -x
 # Exit on unset variable.
 set -u
 
-./node_modules/.bin/prettier --check app
+# Watch frontend sources and re-run bundler automatically.
+./node_modules/.bin/rollup --config --watch

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
+    "prettier": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+      "dev": true
+    },
+    "rollup": {
+      "version": "2.42.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.42.0.tgz",
+      "integrity": "sha512-P9bJnaZ2P0hawoJo+Jto8YZZqil9URogNVE4KJeyj6wrUSDIbdMvmj7CsyEFwdXu/I5SiWEzB1hfmLeMldH6ww==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.3.1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "devDependencies": {
+    "prettier": "2.0.5",
+    "rollup": "2.42.0"
+  }
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,7 @@
+export default [{
+  input: "app/static/js/app.js",
+  output: {
+    file: "app/static/dist/app.js",
+    format: "module",
+  },
+}];


### PR DESCRIPTION
> **This PR is still WIP. So far only the dev and CI environments work, the “real” install scripts are not adjusted yet.**

As part of https://github.com/mtlynch/tinypilot/issues/538, this PR introduces a bundler for the frontend assets.

## Remarks
- I picked [rollup.js](https://rollupjs.org/guide/en/) for now – it’s relatively simple to setup and straightforward to use. As long as we stay away from making the config/setup fancy and sophisticated, we are able to just swap out the bundler later should it doesn’t fit our needs anymore.
- Having a frontend bundler inevitably introduces an additional build step in order to run the app. That means that executing the bundler is now mandatory in order to run the app.
- Checking in `package-lock.json` is [generally recommended](https://stackoverflow.com/a/44210813) because it pins the exact versions and checksums, and thereby allows for deterministic builds.
- As an “aside” this PR brings down the transferred JS files from 12 to 8 by bundling the dependencies of `app.js`.
