### PR TITLE
Revise user-facing error messages

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -340,16 +340,18 @@ document
 for (const button of document.getElementsByClassName("manual-modifier-btn")) {
   button.addEventListener("click", onManualModifierButtonClicked);
 }
-document
-  .getElementById("update-dialog")
-  .addEventListener("update-failure", (evt) => {
+
+const errorEventRegistry = [
+  "update-failure",
+  "change-hostname-failure",
+  "shutdown-failure",
+];
+errorEventRegistry.forEach((name) => {
+  document.addEventListener(name, (evt) => {
     showError(evt.detail);
   });
-document
-  .getElementById("change-hostname-dialog")
-  .addEventListener("change-hostname-failure", (evt) => {
-    showError(evt.detail);
-  });
+});
+
 document
   .getElementById("paste-overlay")
   .addEventListener("paste-text", (evt) => {
@@ -364,9 +366,6 @@ shutdownDialog.addEventListener("shutdown-started", (evt) => {
   for (const elementId of ["remote-screen", "on-screen-keyboard"]) {
     hideElementById(elementId);
   }
-});
-shutdownDialog.addEventListener("shutdown-failure", (evt) => {
-  showError(evt.detail);
 });
 
 socket.on("connect", onSocketConnect);

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -31,7 +31,8 @@ function isElementShown(id) {
   return document.getElementById(id).style.display !== "none";
 }
 
-function showError(title, message, details) {
+function showError({ title, message, details }) {
+  console.error(`${title}:\n${details}`);
   document.getElementById("error-dialog").setup(title, message, details);
   document.getElementById("error-overlay").show();
 }
@@ -342,12 +343,12 @@ for (const button of document.getElementsByClassName("manual-modifier-btn")) {
 document
   .getElementById("update-dialog")
   .addEventListener("update-failure", (evt) => {
-    showError(evt.detail.summary, evt.detail.detail);
+    showError(evt.detail);
   });
 document
   .getElementById("change-hostname-dialog")
   .addEventListener("change-hostname-failure", (evt) => {
-    showError(evt.detail.summary, evt.detail.detail);
+    showError(evt.detail);
   });
 document
   .getElementById("paste-overlay")
@@ -365,7 +366,7 @@ shutdownDialog.addEventListener("shutdown-started", (evt) => {
   }
 });
 shutdownDialog.addEventListener("shutdown-failure", (evt) => {
-  showError(evt.detail.summary, evt.detail.detail);
+  showError(evt.detail);
 });
 
 socket.on("connect", onSocketConnect);

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -31,6 +31,9 @@ function isElementShown(id) {
   return document.getElementById(id).style.display !== "none";
 }
 
+/**
+ * @see the `setup` method in error-dialog.html for the `errorInfo` param
+ */
 function showError(errorInfo) {
   console.error(`${errorInfo.title}:\n${errorInfo.details}`);
   document.getElementById("error-dialog").setup(errorInfo);

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -341,12 +341,12 @@ for (const button of document.getElementsByClassName("manual-modifier-btn")) {
   button.addEventListener("click", onManualModifierButtonClicked);
 }
 
-const errorEventRegistry = [
+const errorEvents = [
   "update-failure",
   "change-hostname-failure",
   "shutdown-failure",
 ];
-errorEventRegistry.forEach((name) => {
+errorEvents.forEach((name) => {
   document.addEventListener(name, (evt) => {
     showError(evt.detail);
   });

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -31,9 +31,9 @@ function isElementShown(id) {
   return document.getElementById(id).style.display !== "none";
 }
 
-function showError({ title, message, details }) {
-  console.error(`${title}:\n${details}`);
-  document.getElementById("error-dialog").setup(title, message, details);
+function showError(errorInfo) {
+  console.error(`${errorInfo.title}:\n${errorInfo.details}`);
+  document.getElementById("error-dialog").setup(errorInfo);
   document.getElementById("error-overlay").show();
 }
 

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -189,7 +189,7 @@
             .catch((error) => {
               this._handleHostnameChangeFailure(
                 "Failed to Determine Hostname",
-                "Please refresh the page and try again.",
+                null,
                 error
               );
             });
@@ -233,7 +233,7 @@
               }
               this._handleHostnameChangeFailure(
                 "Failed to Change Hostname",
-                "Please refresh the page and try again.",
+                null,
                 error
               );
             });

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -258,8 +258,8 @@
               this._handleHostnameChangeFailure({
                 title: "Failed to Redirect",
                 message:
-                  "Cannot reach TinyPilot under the new hostname. The device may" +
-                  " have failed to reboot, or your browser is failing to " +
+                  "Cannot reach TinyPilot under the new hostname. The device" +
+                  "may have failed to reboot, or your browser is failing to " +
                   " resolve the new hostname.",
                 details: error,
               });

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -187,11 +187,10 @@
               this.state = "prompt";
             })
             .catch((error) => {
-              this._handleHostnameChangeFailure(
-                "Failed to Determine Hostname",
-                null,
-                error
-              );
+              this._handleHostnameChangeFailure({
+                title: "Failed to Determine Hostname",
+                details: error,
+              });
             });
         }
 
@@ -231,11 +230,10 @@
                 this.state = "prompt";
                 return;
               }
-              this._handleHostnameChangeFailure(
-                "Failed to Change Hostname",
-                null,
-                error
-              );
+              this._handleHostnameChangeFailure({
+                title: "Failed to Change Hostname",
+                details: error,
+              });
             });
         }
 
@@ -257,21 +255,22 @@
               window.location = futureLocation;
             })
             .catch((error) => {
-              this._handleHostnameChangeFailure(
-                "Failed to Redirect",
-                "Cannot reach TinyPilot under the new hostname. The device may" +
+              this._handleHostnameChangeFailure({
+                title: "Failed to Redirect",
+                message:
+                  "Cannot reach TinyPilot under the new hostname. The device may" +
                   " have failed to reboot, or your browser is failing to " +
                   " resolve the new hostname.",
-                error
-              );
+                details: error,
+              });
             });
         }
 
-        _handleHostnameChangeFailure(title, message, details) {
+        _handleHostnameChangeFailure(errorInfo) {
           this._close();
           this.dispatchEvent(
             new CustomEvent("change-hostname-failure", {
-              detail: { title, message, details },
+              detail: errorInfo,
               bubbles: true,
               composed: true,
             })

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -188,7 +188,8 @@
             })
             .catch((error) => {
               this._handleHostnameChangeFailure(
-                "Failed to determine hostname",
+                "Failed to Determine Hostname",
+                "Please refresh the page and try again.",
                 error
               );
             });
@@ -231,7 +232,8 @@
                 return;
               }
               this._handleHostnameChangeFailure(
-                "Failed to change hostname",
+                "Failed to Change Hostname",
+                "Please refresh the page and try again.",
                 error
               );
             });
@@ -255,21 +257,21 @@
               window.location = futureLocation;
             })
             .catch((error) => {
-              console.error(error);
               this._handleHostnameChangeFailure(
-                "Failed to redirect",
+                "Failed to Redirect",
                 "Cannot reach TinyPilot under the new hostname. The device may" +
                   " have failed to reboot, or your browser is failing to " +
-                  " resolve the new hostname."
+                  " resolve the new hostname.",
+                error
               );
             });
         }
 
-        _handleHostnameChangeFailure(summary, detail) {
+        _handleHostnameChangeFailure(title, message, details) {
           this._close();
           this.dispatchEvent(
             new CustomEvent("change-hostname-failure", {
-              detail: { summary, detail },
+              detail: { title, message, details },
               bubbles: true,
               composed: true,
             })

--- a/app/templates/custom-elements/error-dialog.html
+++ b/app/templates/custom-elements/error-dialog.html
@@ -40,7 +40,6 @@
     customElements.define(
       "error-dialog",
       class extends HTMLElement {
-        // TODO(jotaen) Make this importable once we have JS modules.
         DEFAULT_MESSAGE = "Please refresh the page and try again.";
 
         connectedCallback() {
@@ -60,10 +59,9 @@
          * @param details (optional) The technical error details, e.g. the
          *                original error message from the API or library call.
          */
-        setup(title, message, details = "") {
+        setup({ title, message = this.DEFAULT_MESSAGE, details = "" }) {
           this.shadowRoot.getElementById("title").innerText = title;
-          this.shadowRoot.getElementById("message").innerText =
-            message || this.DEFAULT_MESSAGE;
+          this.shadowRoot.getElementById("message").innerText = message;
           this.shadowRoot.getElementById("details").innerText = details;
           this.shadowRoot.getElementById(
             "details-container"

--- a/app/templates/custom-elements/error-dialog.html
+++ b/app/templates/custom-elements/error-dialog.html
@@ -40,6 +40,7 @@
     customElements.define(
       "error-dialog",
       class extends HTMLElement {
+        // TODO(jotaen) Make this importable once we have JS modules.
         DEFAULT_MESSAGE = "Please refresh the page and try again.";
 
         connectedCallback() {

--- a/app/templates/custom-elements/error-dialog.html
+++ b/app/templates/custom-elements/error-dialog.html
@@ -40,6 +40,8 @@
     customElements.define(
       "error-dialog",
       class extends HTMLElement {
+        DEFAULT_MESSAGE = "Please refresh the page and try again.";
+
         connectedCallback() {
           this.attachShadow({ mode: "open" });
           this.shadowRoot.appendChild(template.content.cloneNode(true));
@@ -51,14 +53,16 @@
 
         /**
          * @param title   A concise summary of the error.
-         * @param message A user-friendly and helpful message that (ideally)
-         *                gives the user some guidance what to do now.
+         * @param message (optional) A user-friendly and helpful message that
+         *                (ideally) gives the user some guidance what to do
+         *                now. Defaults to a generic `DEFAULT_MESSAGE`.
          * @param details (optional) The technical error details, e.g. the
          *                original error message from the API or library call.
          */
         setup(title, message, details = "") {
           this.shadowRoot.getElementById("title").innerText = title;
-          this.shadowRoot.getElementById("message").innerText = message;
+          this.shadowRoot.getElementById("message").innerText =
+            message || this.DEFAULT_MESSAGE;
           this.shadowRoot.getElementById("details").innerText = details;
           this.shadowRoot.getElementById(
             "details-container"

--- a/app/templates/custom-elements/shutdown-dialog.html
+++ b/app/templates/custom-elements/shutdown-dialog.html
@@ -120,12 +120,14 @@
             .catch((error) => {
               if (restart) {
                 this._handleShutdownFailure(
-                  "Failed to restart TinyPilot device",
+                  "Failed to Restart TinyPilot Device",
+                  "Please refresh this page and try again.",
                   error
                 );
               } else {
                 this._handleShutdownFailure(
-                  "Failed to shut down TinyPilot device",
+                  "Failed to Shut Down TinyPilot Device",
+                  "Please refresh this page and try again.",
                   error
                 );
               }
@@ -142,11 +144,11 @@
           );
         }
 
-        _handleShutdownFailure(summary, detail) {
+        _handleShutdownFailure(title, message, details) {
           this._close();
           this.dispatchEvent(
             new CustomEvent("shutdown-failure", {
-              detail: { summary, detail },
+              detail: { title, message, details },
               bubbles: true,
               composed: true,
             })

--- a/app/templates/custom-elements/shutdown-dialog.html
+++ b/app/templates/custom-elements/shutdown-dialog.html
@@ -121,13 +121,13 @@
               if (restart) {
                 this._handleShutdownFailure(
                   "Failed to Restart TinyPilot Device",
-                  "Please refresh this page and try again.",
+                  null,
                   error
                 );
               } else {
                 this._handleShutdownFailure(
                   "Failed to Shut Down TinyPilot Device",
-                  "Please refresh this page and try again.",
+                  null,
                   error
                 );
               }

--- a/app/templates/custom-elements/shutdown-dialog.html
+++ b/app/templates/custom-elements/shutdown-dialog.html
@@ -119,17 +119,15 @@
             })
             .catch((error) => {
               if (restart) {
-                this._handleShutdownFailure(
-                  "Failed to Restart TinyPilot Device",
-                  null,
-                  error
-                );
+                this._handleShutdownFailure({
+                  title: "Failed to Restart TinyPilot Device",
+                  details: error,
+                });
               } else {
-                this._handleShutdownFailure(
-                  "Failed to Shut Down TinyPilot Device",
-                  null,
-                  error
-                );
+                this._handleShutdownFailure({
+                  title: "Failed to Shut Down TinyPilot Device",
+                  details: error,
+                });
               }
             });
         }
@@ -144,11 +142,11 @@
           );
         }
 
-        _handleShutdownFailure(title, message, details) {
+        _handleShutdownFailure(errorInfo) {
           this._close();
           this.dispatchEvent(
             new CustomEvent("shutdown-failure", {
-              detail: { title, message, details },
+              detail: errorInfo,
               bubbles: true,
               composed: true,
             })

--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -146,7 +146,7 @@
             .catch((error) => {
               this._handleUpdateFailure(
                 "Failed to Retrieve Version Information",
-                "Please refresh this page and try again.",
+                null,
                 error
               );
             });
@@ -172,7 +172,7 @@
             .catch((error) => {
               this._handleUpdateFailure(
                 "Failed to Restart TinyPilot Device",
-                "Please refresh this page and try again.",
+                null,
                 error
               );
             });
@@ -199,11 +199,7 @@
           try {
             await this._startUpdateWithRetries();
           } catch (error) {
-            this._handleUpdateFailure(
-              "Failed to Start Update",
-              "Please refresh this page and try again.",
-              error
-            );
+            this._handleUpdateFailure("Failed to Start Update", null, error);
             return;
           }
 
@@ -213,11 +209,7 @@
             await controllers.refreshCsrfToken();
             await this._performRestart();
           } catch (error) {
-            this._handleUpdateFailure(
-              "Failed to Complete Update",
-              "Please refresh this page and try again.",
-              error
-            );
+            this._handleUpdateFailure("Failed to Complete Update", null, error);
             return;
           }
         }

--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -145,7 +145,8 @@
             })
             .catch((error) => {
               this._handleUpdateFailure(
-                "Failed to retrieve version information",
+                "Failed to Retrieve Version Information",
+                "Please refresh this page and try again.",
                 error
               );
             });
@@ -170,7 +171,8 @@
             })
             .catch((error) => {
               this._handleUpdateFailure(
-                "Failed to restart TinyPilot device",
+                "Failed to Restart TinyPilot Device",
+                "Please refresh this page and try again.",
                 error
               );
             });
@@ -197,7 +199,11 @@
           try {
             await this._startUpdateWithRetries();
           } catch (error) {
-            this._handleUpdateFailure("Failed to start update", error);
+            this._handleUpdateFailure(
+              "Failed to Start Update",
+              "Please refresh this page and try again.",
+              error
+            );
             return;
           }
 
@@ -207,20 +213,20 @@
             await controllers.refreshCsrfToken();
             await this._performRestart();
           } catch (error) {
-            console.error(error);
             this._handleUpdateFailure(
-              "Failed to complete update",
-              "Please refresh this page and try again. Error details: " + error
+              "Failed to Complete Update",
+              "Please refresh this page and try again.",
+              error
             );
             return;
           }
         }
 
-        _handleUpdateFailure(summary, detail) {
+        _handleUpdateFailure(title, message, details) {
           this._close();
           this.dispatchEvent(
             new CustomEvent("update-failure", {
-              detail: { summary, detail },
+              detail: { title, message, details },
               bubbles: true,
               composed: true,
             })

--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -144,11 +144,10 @@
               }
             })
             .catch((error) => {
-              this._handleUpdateFailure(
-                "Failed to Retrieve Version Information",
-                null,
-                error
-              );
+              this._handleUpdateFailure({
+                title: "Failed to Retrieve Version Information",
+                details: error,
+              });
             });
         }
 
@@ -170,11 +169,10 @@
               this.state = "restarting";
             })
             .catch((error) => {
-              this._handleUpdateFailure(
-                "Failed to Restart TinyPilot Device",
-                null,
-                error
-              );
+              this._handleUpdateFailure({
+                title: "Failed to Restart TinyPilot Device",
+                details: error,
+              });
             });
         }
 
@@ -199,7 +197,10 @@
           try {
             await this._startUpdateWithRetries();
           } catch (error) {
-            this._handleUpdateFailure("Failed to Start Update", null, error);
+            this._handleUpdateFailure({
+              title: "Failed to Start Update",
+              details: error,
+            });
             return;
           }
 
@@ -209,16 +210,19 @@
             await controllers.refreshCsrfToken();
             await this._performRestart();
           } catch (error) {
-            this._handleUpdateFailure("Failed to Complete Update", null, error);
+            this._handleUpdateFailure({
+              title: "Failed to Complete Update",
+              details: error,
+            });
             return;
           }
         }
 
-        _handleUpdateFailure(title, message, details) {
+        _handleUpdateFailure(errorInfo) {
           this._close();
           this.dispatchEvent(
             new CustomEvent("update-failure", {
-              detail: { title, message, details },
+              detail: errorInfo,
               bubbles: true,
               composed: true,
             })

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -177,9 +177,9 @@
             document.getElementById("error-dialog").setup({
               title: "Example Error Message",
               message:
-                "The title is set in Title Case. The message should be user-friendly" +
-                " and ideally provide some guidance. Technical error messages can" +
-                " be displayed in the “details” box below.",
+                "The title is set in Title Case. The message should be" +
+                " user-friendly and ideally provide some guidance. Technical" +
+                " error messages can be displayed in the “details” box below.",
               details:
                 "" +
                 "dummyElementFailed: line 502\n" +

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -174,20 +174,20 @@
         document
           .getElementById("show-error-overlay-btn")
           .addEventListener("click", () => {
-            document
-              .getElementById("error-dialog")
-              .setup(
-                "Example Error Message",
+            document.getElementById("error-dialog").setup({
+              title: "Example Error Message",
+              message:
                 "The title is set in Title Case. The message should be user-friendly" +
-                  " and ideally provide some guidance. Technical error messages can" +
-                  " be displayed in the “details” box below.",
+                " and ideally provide some guidance. Technical error messages can" +
+                " be displayed in the “details” box below.",
+              details:
                 "" +
-                  "dummyElementFailed: line 502\n" +
-                  "  dummyParentElement returned unexpected response: foo\n" +
-                  "    exhausted resources.\n" +
-                  "Stacktrace:\n" +
-                  "  fooBarBaz\n".repeat(80)
-              );
+                "dummyElementFailed: line 502\n" +
+                "  dummyParentElement returned unexpected response: foo\n" +
+                "    exhausted resources.\n" +
+                "Stacktrace:\n" +
+                "  fooBarBaz\n".repeat(80),
+            });
             document.getElementById("error-overlay").show();
           });
       </script>


### PR DESCRIPTION
This PR ensures that all error messages comply with the rules given in the style guide.

- Use “Title Case” for the title
- Display the technical error inside the “details” box
- Show an actionable, user-friendly message (for this PR the message is generic, as the error case itself is unspecific)
- Log to `console.error` centrally
- Streamline/cleanup the control flow a little bit

I’m not *super* happy with how the default error message fallback is implemented. Ideally I think we should have a central helper for generating the error data structure that we can import, to make the whole setup a bit less repetitive. I would hold off on further refactorings, though, until we have bundling and modules.

<img width="839" alt="Screenshot 2021-03-23 at 17 10 04" src="https://user-images.githubusercontent.com/3618384/112179066-a28a7580-8bfa-11eb-995f-f001f87ff37c.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mtlynch/tinypilot/605)
<!-- Reviewable:end -->
