### PR TITLE
Hide scrollbars in error details pane unless the text overflows

### DIFF
--- a/app/templates/custom-elements/error-dialog.html
+++ b/app/templates/custom-elements/error-dialog.html
@@ -5,7 +5,7 @@
     #details {
       padding: 0.5rem;
       max-height: 50vh;
-      overflow: scroll;
+      overflow: auto;
       opacity: 0.7;
       border: 1px solid black;
       background-color: white;


### PR DESCRIPTION
Changes the overflow setting to 'auto' so that horizontal and vertical scrollbars show up only when necessary rather than automatically.

### Before

![image](https://user-images.githubusercontent.com/7783288/112206609-8089f680-8bec-11eb-97b3-aad039290c3c.png)

### After

![image](https://user-images.githubusercontent.com/7783288/112206524-6cde9000-8bec-11eb-8a84-052384283921.png)
