### PR TITLE
Error details: break lines so that we never overflow horizontally

### DIFF
--- a/app/templates/custom-elements/error-dialog.html
+++ b/app/templates/custom-elements/error-dialog.html
@@ -11,6 +11,8 @@
       background-color: white;
       text-align: left;
       font-size: 0.8em;
+      white-space: pre-wrap;
+      overflow-wrap: break-word;
     }
 
     .details-label {

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -185,6 +185,9 @@
                 "dummyElementFailed: line 502\n" +
                 "  dummyParentElement returned unexpected response: foo\n" +
                 "    exhausted resources.\n" +
+                "Location: 0x88b9d154cd90076610f3fc27df06bbd8b37b62ffe1fa8ade" +
+                "1d469d5cf911820fcc850249accacba5a690720bb9eca9813662348ff6a1" +
+                "ace3c0076610f3fc2711820fcdf06bb\n" +
                 "Stacktrace:\n" +
                 "  fooBarBaz\n".repeat(80),
             });


### PR DESCRIPTION
You mentioned once that the details box is helpful so that people can make screenshots of the error message. For that purpose it might be good if the text never overflows horizontally, because then information would be missing in the screenshot. Of course, the text can still overflow vertically, but that probably happens less often and it’s less likely for people to miss (compared to horizontal overflow).

<img width="821" alt="Screenshot 2021-03-24 at 11 33 52" src="https://user-images.githubusercontent.com/3618384/112296061-d1edc080-8c94-11eb-992b-89b39fc3d2f5.png">
