### PR TITLE
Register default JSON error handler

### DIFF
--- a/app/json_response.py
+++ b/app/json_response.py
@@ -4,15 +4,15 @@ import flask
 # The default dictionary is okay because we're not modifying it.
 # pylint: disable=dangerous-default-value
 def success(fields={}):
-    """A JSON-API response indicating a successful request.
+    """A JSON response for a successful request.
+
     Args:
         fields: Dictionary with JSON properties to include.
 
     Returns:
-        A `flask.Response` object with JSON body. The JSON structure always
-        contains a `success` property (which is `true`) and an `error` property
-        (which is `null`). There may appear additional endpoint-dependent
-        properties.
+        A `flask.Response` object with JSON body. The JSON structure contains a
+        `success` property (which is `true`) and an `error` property (which is
+        `null`). The additional fields given are merged into the JSON output.
     """
     response = {
         'success': True,
@@ -24,14 +24,15 @@ def success(fields={}):
 
 
 def error(message):
-    """A JSON-API response indicating a failed request.
+    """A JSON response for a failed request.
+
     Args:
         message: String containing the error message.
 
     Returns:
-        A `flask.Response` object with JSON body. The JSON structure always
-        contains a `success` property (which is `false`) and an `error` property
-        (which is a string containing the error message).
+        A `flask.Response` object with JSON body. The JSON structure contains a
+        `success` property (which is `false`) and an `error` property (which is
+        a string containing the error message).
     """
     return flask.jsonify({
         'success': False,

--- a/app/json_response.py
+++ b/app/json_response.py
@@ -1,0 +1,39 @@
+import flask
+
+
+# The default dictionary is okay because we're not modifying it.
+# pylint: disable=dangerous-default-value
+def success(fields={}):
+    """A JSON-API response indicating a successful request.
+    Args:
+        fields: Dictionary with JSON properties to include.
+
+    Returns:
+        A `flask.Response` object with JSON body. The JSON structure always
+        contains a `success` property (which is `true`) and an `error` property
+        (which is `null`). There may appear additional endpoint-dependent
+        properties.
+    """
+    response = {
+        'success': True,
+        'error': None,
+    }
+    for key, val in fields.items():
+        response[key] = val
+    return flask.jsonify(response)
+
+
+def error(message):
+    """A JSON-API response indicating a failed request.
+    Args:
+        message: String containing the error message.
+
+    Returns:
+        A `flask.Response` object with JSON body. The JSON structure always
+        contains a `success` property (which is `false`) and an `error` property
+        (which is a string containing the error message).
+    """
+    return flask.jsonify({
+        'success': False,
+        'error': message,
+    })

--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ import os
 
 import flask
 import flask_wtf
+from werkzeug.exceptions import HTTPException
 
 import api
 import json_response
@@ -62,6 +63,15 @@ def after_request(response):
         response.headers['Expires'] = 0
         response.headers['Pragma'] = 'no-cache'
     return response
+
+
+@app.errorhandler(Exception)
+def handle_error(e):
+    logger.exception(e)
+    code = 500
+    if isinstance(e, HTTPException):
+        code = e.code
+    return json_response.error(str(e)), code
 
 
 def main():

--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ import flask
 import flask_wtf
 
 import api
+import json_response
 import socket_api
 import views
 from find_files import find as find_files
@@ -49,10 +50,7 @@ app.register_blueprint(views.views_blueprint)
 
 @app.errorhandler(flask_wtf.csrf.CSRFError)
 def handle_csrf_error(error):
-    return flask.jsonify({
-        'success': False,
-        'error': error.description,
-    }), 400
+    return json_response.error(error.description), 400
 
 
 @app.after_request

--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,7 @@ import os
 
 import flask
 import flask_wtf
-from werkzeug.exceptions import HTTPException
+from werkzeug import exceptions
 
 import api
 import json_response
@@ -69,7 +69,7 @@ def after_request(response):
 def handle_error(e):
     logger.exception(e)
     code = 500
-    if isinstance(e, HTTPException):
+    if isinstance(e, exceptions.HTTPException):
         code = e.code
     return json_response.error(str(e)), code
 


### PR DESCRIPTION
Fixes https://github.com/mtlynch/tinypilot/issues/505 by introducing a “catch-all” exception handler that makes sure we always compose a valid JSON response and don’t accidentally return the Werkzeug HTML page or plain text. That practically means that internal server errors (`500`) or routing errors (`404`) will now yield a JSON response according to our convention.

Also eventually fixes https://github.com/tiny-pilot/tinypilot-pro/issues/53 (last remaining action item).

## Remarks
- I pulled out the factory functions to create flask responses, because I didn’t want to repeat them inline again in `main.py`.
- I took over the status code from the `HTTPException` (if applicable) or default to `500` respectively. This is inline with the previous behaviour, even though it’s not consistent with our own convention, which is to use `200` all the way. In anticipation of https://github.com/mtlynch/tinypilot/issues/506 I wouldn’t change this now but leave it like this.
- The traceback/stacktrace for internal server errors isn’t returned to the client anymore, but it appears in the server logs. I think there is no need to expose it to the outside.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mtlynch/tinypilot/612)
<!-- Reviewable:end -->
