### PR TITLE
Refactoring page title prefix logic

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -3,8 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>
-      {% if hostname and hostname.lower() != 'tinypilot' %}{{ hostname }} - {%
-      endif %}TinyPilot
+      {{ page_title_prefix }}TinyPilot
     </title>
     <link rel="stylesheet" type="text/css" href="/css/style.css" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />

--- a/app/views.py
+++ b/app/views.py
@@ -5,12 +5,15 @@ from find_files import find as find_files
 
 views_blueprint = flask.Blueprint('views', __name__, url_prefix='')
 
+# Default hostname of TinyPilot device.
+_DEFAULT_HOSTNAME = 'tinypilot'
+
 
 @views_blueprint.route('/', methods=['GET'])
 def index_get():
     return flask.render_template(
         'index.html',
-        hostname=hostname.determine(),
+        page_title_prefix=_page_title_prefix(),
         custom_elements_files=find_files.custom_elements_files())
 
 
@@ -33,3 +36,9 @@ def stream_get():
     if flask.current_app.debug:
         return flask.send_file('testdata/test-remote-screen.jpg')
     return flask.abort(404)
+
+
+def _page_title_prefix():
+    if hostname.determine().lower() != _DEFAULT_HOSTNAME.lower():
+        return '%s - ' % hostname.determine()
+    return ''


### PR DESCRIPTION
Refactor the page title prefix so that it's in views.py instead of index.html. In the Pro version, there are more views, so it's easier to share the logic if it's in views.py.