### PR TITLE
Listen only on localhost by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ TinyPilot accepts various options through environment variables:
 
 | Environment Variable | Default      | Description |
 |----------------------|--------------|-------------|
-| `HOST`               | `0.0.0.0`    | Network interface to listen for incoming connections. |
+| `HOST`               | `127.0.0.1`  | Network interface to listen for incoming connections. |
 | `PORT`               | `8000`       | HTTP port to listen for incoming connections. |
 | `KEYBOARD_PATH`      | `/dev/hidg0` | Path to keyboard HID interface. |
 | `MOUSE_PATH`         | `/dev/hidg1` | Path to mouse HID interface. |

--- a/app/main.py
+++ b/app/main.py
@@ -13,7 +13,7 @@ import socket_api
 import views
 from find_files import find as find_files
 
-host = os.environ.get('HOST', None)
+host = os.environ.get('HOST', '127.0.0.1')
 port = int(os.environ.get('PORT', 8000))
 debug = 'DEBUG' in os.environ
 use_reloader = os.environ.get('USE_RELOADER', '1') == '1'

--- a/app/main.py
+++ b/app/main.py
@@ -13,7 +13,7 @@ import socket_api
 import views
 from find_files import find as find_files
 
-host = os.environ.get('HOST', '0.0.0.0')
+host = os.environ.get('HOST', None)
 port = int(os.environ.get('PORT', 8000))
 debug = 'DEBUG' in os.environ
 use_reloader = os.environ.get('USE_RELOADER', '1') == '1'

--- a/dev-scripts/serve-dev
+++ b/dev-scripts/serve-dev
@@ -10,4 +10,5 @@ set -x
 set -u
 
 # Serve TinyPilot in dev mode.
-PORT=8000 KEYBOARD_PATH=/dev/null MOUSE_PATH=/dev/null DEBUG=1 ./app/main.py
+HOST=0.0.0.0 PORT=8000 KEYBOARD_PATH=/dev/null MOUSE_PATH=/dev/null DEBUG=1 \
+  ./app/main.py


### PR DESCRIPTION
Listening on all interfaces is really only useful during development. In production, nginx forwards requests to TinyPilot, so TinyPilot doesn't need to listen on any non-localhost interface.

While I can't think of any security issues related to this, it's safer if we reduce the attack surface by listening only on on interfaces that are strictly required in production.