### PR TITLE
Abstracting away concept of 'version'

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -1,13 +1,13 @@
 import flask
 
 import debug_logs
-import git
 import hostname
 import json_response
 import local_system
 import request_parsers.errors
 import request_parsers.hostname
 import update
+import version
 
 api_blueprint = flask.Blueprint('api', __name__, url_prefix='/api')
 
@@ -112,8 +112,8 @@ def version_get():
         }
     """
     try:
-        return json_response.success({'version': git.local_head_commit_id()})
-    except git.Error as e:
+        return json_response.success({'version': version.local_version()})
+    except version.Error as e:
         return json_response.error(str(e)), 200
 
 
@@ -142,8 +142,8 @@ def latest_release_get():
         }
     """
     try:
-        return json_response.success({'version': git.remote_head_commit_id()})
-    except git.Error as e:
+        return json_response.success({'version': version.latest_version()})
+    except version.Error as e:
         return json_response.error(str(e)), 200
 
 

--- a/app/version.py
+++ b/app/version.py
@@ -1,0 +1,24 @@
+import git
+
+
+class Error(Exception):
+    pass
+
+
+class GitError(Error):
+    pass
+
+
+def local_version():
+    try:
+        return git.local_head_commit_id()
+    except git.Error as e:
+        raise GitError('Failed to check local version: %s' % str(e)) from e
+
+
+def latest_version():
+    try:
+        return git.remote_head_commit_id()
+    except git.Error as e:
+        raise GitError('Failed to check latest available version: %s' %
+                       str(e)) from e


### PR DESCRIPTION
TinyPilot Pro and TinyPilot Community Edition use different logic to check the local and latest version. Abstracting it into a version module will lead to fewer merge conflicts when sharing code between the two repositories.