### PR TITLE
Deprecate TINYPILOT_INSTALL_VARS in quick-install script

### DIFF
--- a/quick-install
+++ b/quick-install
@@ -6,34 +6,50 @@ set -e
 # Echo commands to stdout.
 set -x
 
-readonly TINYPILOT_SETTINGS_FILE="/home/tinypilot/settings.yml"
+#######################################
+# Adds a setting to the YAML settings file, if it's not yet defined.
+# Globals:
+#   TINYPILOT_SETTINGS_FILE, a path.
+# Arguments:
+#   Key to define.
+#   Value to set.
+# Outputs:
+#   The line appended to the settings file, if the variable wasn't yet defined.
+#######################################
+add_setting_if_undefined() {
+  local file="${TINYPILOT_SETTINGS_FILE}"
+  local key="${1}"
+  local value="${2}"
+  if ! grep --silent "^${key}:" "${file}"; then
+    echo "${key}: ${value}" | tee --append "${file}"
+  fi
+}
+
+readonly DEFAULT_TINYPILOT_SETTINGS_FILE="/home/tinypilot/settings.yml"
 
 if [[ -n "${TINYPILOT_INSTALL_VARS}" ]]; then
   echo "TINYPILOT_INSTALL_VARS is no longer supported." >&2
-  echo "Please specify extra settings via the ${TINYPILOT_SETTINGS_FILE} file." >&2
+  echo "Please specify extra settings via the ${DEFAULT_TINYPILOT_SETTINGS_FILE} file." >&2
   exit 255
 fi
 
 # Treat undefined environment variables as errors.
 set -u
 
-# Check if there's a settings file with extra installation settings.
-if [[ -f "${TINYPILOT_SETTINGS_FILE}" ]]; then
-  echo "Using settings file at: ${TINYPILOT_SETTINGS_FILE}"
+# Create a temporary settings file that will be used throughout this script to
+# avoid repeatedly using sudo.
+readonly TINYPILOT_SETTINGS_FILE="$(mktemp --suffix ".yml")"
+# Check if there's already a settings file with extra installation settings.
+if [[ -f "${DEFAULT_TINYPILOT_SETTINGS_FILE}" ]]; then
+  echo "Using settings file at: ${DEFAULT_TINYPILOT_SETTINGS_FILE}"
+  sudo cp "${DEFAULT_TINYPILOT_SETTINGS_FILE}" "${TINYPILOT_SETTINGS_FILE}"
 else
-  echo "No pre-existing settings file found at: ${TINYPILOT_SETTINGS_FILE}"
-  sudo touch "${TINYPILOT_SETTINGS_FILE}"
+  echo "No pre-existing settings file found at: ${DEFAULT_TINYPILOT_SETTINGS_FILE}"
 fi
-sudo chown "$(whoami):$(whoami)" "${TINYPILOT_SETTINGS_FILE}"
 readonly EXTRA_VARS_PATH="@${TINYPILOT_SETTINGS_FILE}"
 
 # Set default installation settings
-if ! grep --silent "^ustreamer_interface:" "${TINYPILOT_SETTINGS_FILE}"; then
-  echo "ustreamer_interface: 127.0.0.1" >> ${TINYPILOT_SETTINGS_FILE}
-fi
-if ! grep --silent "^ustreamer_port:" "${TINYPILOT_SETTINGS_FILE}"; then
-  echo "ustreamer_port: 8001" >> ${TINYPILOT_SETTINGS_FILE}
-fi
+add_setting_if_undefined "ustreamer_port" "8001"
 
 # Check if this system uses the TC358743 HDMI to CSI capture bridge.
 USE_TC358743_DEFAULTS=''
@@ -50,22 +66,15 @@ fi
 # If this system does not use a TC358743 capture chip, set defaults for any
 # unset install variables.
 if [ -z "$USE_TC358743_DEFAULTS" ]; then
-  if ! grep --silent "^ustreamer_encoder:" "${TINYPILOT_SETTINGS_FILE}"; then
-    echo "ustreamer_encoder: hw" >> ${TINYPILOT_SETTINGS_FILE}
-  fi
-  if ! grep --silent "^ustreamer_format:" "${TINYPILOT_SETTINGS_FILE}"; then
-    echo "ustreamer_format: jpeg" >> ${TINYPILOT_SETTINGS_FILE}
-  fi
-  if ! grep --silent "^ustreamer_resolution:" "${TINYPILOT_SETTINGS_FILE}"; then
-    echo "ustreamer_resolution: 1920x1080" >> ${TINYPILOT_SETTINGS_FILE}
-  fi
-  if ! grep --silent "^ustreamer_persistent:" "${TINYPILOT_SETTINGS_FILE}"; then
-    echo "ustreamer_persistent: true" >> ${TINYPILOT_SETTINGS_FILE}
-  fi
-  if ! grep --silent "^ustreamer_desired_fps:" "${TINYPILOT_SETTINGS_FILE}"; then
-    echo "ustreamer_desired_fps: 30" >> ${TINYPILOT_SETTINGS_FILE}
-  fi
+  add_setting_if_undefined "ustreamer_encoder" "hw"
+  add_setting_if_undefined "ustreamer_format" "jpeg"
+  add_setting_if_undefined "ustreamer_resolution" "1920x1080"
+  add_setting_if_undefined "ustreamer_persistent" "true"
+  add_setting_if_undefined "ustreamer_desired_fps" "30"
 fi
+
+echo "Final install settings:"
+cat "${TINYPILOT_SETTINGS_FILE}"
 
 # Check if the user is accidentally downgrading from TinyPilot Pro.
 HAS_PRO_INSTALLED=0
@@ -161,3 +170,8 @@ echo "- hosts: localhost
     - role: $TINYPILOT_ROLE_NAME" > install.yml
 ansible-playbook -i localhost, install.yml \
   --extra-vars "${EXTRA_VARS_PATH}"
+
+# Copy the final install settings used in this installation back to the default
+# settings location.
+sudo cp "${TINYPILOT_SETTINGS_FILE}" "${DEFAULT_TINYPILOT_SETTINGS_FILE}"
+sudo chown tinypilot:tinypilot "${DEFAULT_TINYPILOT_SETTINGS_FILE}"

--- a/quick-install
+++ b/quick-install
@@ -1,23 +1,44 @@
 #!/bin/bash
 
+# Exit on first error.
+set -e
+
 # Echo commands to stdout.
 set -x
 
-if [ -z "$TINYPILOT_INSTALL_VARS" ]
-then
-  TINYPILOT_INSTALL_VARS=""
-  echo "Using default install vars"
-else
-  echo "User-specified install vars: $TINYPILOT_INSTALL_VARS"
+readonly TINYPILOT_SETTINGS_FILE="/home/tinypilot/settings.yml"
+
+if [[ -n "${TINYPILOT_INSTALL_VARS}" ]]; then
+  echo "TINYPILOT_INSTALL_VARS is no longer supported." >&2
+  echo "Please specify extra settings via the ${TINYPILOT_SETTINGS_FILE} file." >&2
+  exit 255
 fi
 
-# TODO(mtlynch): Move the TINYPILOT_INSTALL_VARS logic into
-#   TINYPILOT_SETTINGS_FILE vars.
+# Treat undefined environment variables as errors.
+set -u
+
+# Check if there's a settings file with extra installation settings.
+if [[ -f "${TINYPILOT_SETTINGS_FILE}" ]]; then
+  echo "Using settings file at: ${TINYPILOT_SETTINGS_FILE}"
+else
+  echo "No pre-existing settings file found at: ${TINYPILOT_SETTINGS_FILE}"
+  sudo touch "${TINYPILOT_SETTINGS_FILE}"
+fi
+sudo chown "$(whoami):$(whoami)" "${TINYPILOT_SETTINGS_FILE}"
+readonly EXTRA_VARS_PATH="@${TINYPILOT_SETTINGS_FILE}"
+
+# Set default installation settings
+if ! grep --silent "^ustreamer_interface:" "${TINYPILOT_SETTINGS_FILE}"; then
+  echo "ustreamer_interface: 127.0.0.1" >> ${TINYPILOT_SETTINGS_FILE}
+fi
+if ! grep --silent "^ustreamer_port:" "${TINYPILOT_SETTINGS_FILE}"; then
+  echo "ustreamer_port: 8001" >> ${TINYPILOT_SETTINGS_FILE}
+fi
 
 # Check if this system uses the TC358743 HDMI to CSI capture bridge.
 USE_TC358743_DEFAULTS=''
-if [[ "$TINYPILOT_INSTALL_VARS" =~ 'ustreamer_capture_device=' ]]; then
-  if [[ "$TINYPILOT_INSTALL_VARS" =~ 'ustreamer_capture_device=tc358743' ]]; then
+if grep --silent "^ustreamer_capture_device:" "${TINYPILOT_SETTINGS_FILE}"; then
+  if grep --silent "^ustreamer_capture_device: tc358743$" "${TINYPILOT_SETTINGS_FILE}"; then
     USE_TC358743_DEFAULTS='y'
   fi
 # Only check the existing config file if user has not set
@@ -29,42 +50,22 @@ fi
 # If this system does not use a TC358743 capture chip, set defaults for any
 # unset install variables.
 if [ -z "$USE_TC358743_DEFAULTS" ]; then
-  if [[ ! "$TINYPILOT_INSTALL_VARS" =~ 'ustreamer_encoder=' ]]; then
-    TINYPILOT_INSTALL_VARS+=" ustreamer_encoder=hw"
+  if ! grep --silent "^ustreamer_encoder:" "${TINYPILOT_SETTINGS_FILE}"; then
+    echo "ustreamer_encoder: hw" >> ${TINYPILOT_SETTINGS_FILE}
   fi
-  if [[ ! "$TINYPILOT_INSTALL_VARS" =~ 'ustreamer_format=' ]]; then
-    TINYPILOT_INSTALL_VARS+=" ustreamer_format=jpeg"
+  if ! grep --silent "^ustreamer_format:" "${TINYPILOT_SETTINGS_FILE}"; then
+    echo "ustreamer_format: jpeg" >> ${TINYPILOT_SETTINGS_FILE}
   fi
-  if [[ ! "$TINYPILOT_INSTALL_VARS" =~ 'ustreamer_resolution=' ]]; then
-    TINYPILOT_INSTALL_VARS+=" ustreamer_resolution=1920x1080"
+  if ! grep --silent "^ustreamer_resolution:" "${TINYPILOT_SETTINGS_FILE}"; then
+    echo "ustreamer_resolution: 1920x1080" >> ${TINYPILOT_SETTINGS_FILE}
   fi
-  if [[ ! "$TINYPILOT_INSTALL_VARS" =~ 'ustreamer_persistent=' ]]; then
-    TINYPILOT_INSTALL_VARS+=" ustreamer_persistent=true"
+  if ! grep --silent "^ustreamer_persistent:" "${TINYPILOT_SETTINGS_FILE}"; then
+    echo "ustreamer_persistent: true" >> ${TINYPILOT_SETTINGS_FILE}
   fi
-  if [[ ! "$TINYPILOT_INSTALL_VARS" =~ 'ustreamer_desired_fps=' ]]; then
-    TINYPILOT_INSTALL_VARS+=" ustreamer_desired_fps=30"
+  if ! grep --silent "^ustreamer_desired_fps:" "${TINYPILOT_SETTINGS_FILE}"; then
+    echo "ustreamer_desired_fps: 30" >> ${TINYPILOT_SETTINGS_FILE}
   fi
 fi
-
-# Treat undefined environment variables as errors.
-set -u
-
-# Exit on first error.
-set -e
-
-echo "Final install vars: $TINYPILOT_INSTALL_VARS"
-
-# Check if there's a settings file with extra installation settings.
-readonly TINYPILOT_SETTINGS_FILE="/home/tinypilot/settings.yml"
-EXTRA_VARS_PATH=""
-if [ -f "${TINYPILOT_SETTINGS_FILE}" ]; then
-  echo "Using settings file at: ${TINYPILOT_SETTINGS_FILE}"
-  EXTRA_VARS_PATH="@${TINYPILOT_SETTINGS_FILE}"
-else
-  echo "No pre-existing settings file found at: ${TINYPILOT_SETTINGS_FILE}"
-  EXTRA_VARS_PATH=""
-fi
-readonly EXTRA_VARS_PATH
 
 # Check if the user is accidentally downgrading from TinyPilot Pro.
 HAS_PRO_INSTALLED=0
@@ -159,5 +160,4 @@ echo "- hosts: localhost
   roles:
     - role: $TINYPILOT_ROLE_NAME" > install.yml
 ansible-playbook -i localhost, install.yml \
-  --extra-vars "${EXTRA_VARS_PATH}" \
-  --extra-vars "${TINYPILOT_INSTALL_VARS}"
+  --extra-vars "${EXTRA_VARS_PATH}"

--- a/quick-install
+++ b/quick-install
@@ -17,11 +17,10 @@ set -x
 #   The line appended to the settings file, if the variable wasn't yet defined.
 #######################################
 add_setting_if_undefined() {
-  local file="${TINYPILOT_SETTINGS_FILE}"
-  local key="${1}"
-  local value="${2}"
-  if ! grep --silent "^${key}:" "${file}"; then
-    echo "${key}: ${value}" | tee --append "${file}"
+  local key="$1"
+  local value="$2"
+  if ! grep --silent "^${key}:" "${TINYPILOT_SETTINGS_FILE}"; then
+    echo "${key}: ${value}" | tee --append "${TINYPILOT_SETTINGS_FILE}"
   fi
 }
 
@@ -38,7 +37,9 @@ set -u
 
 # Create a temporary settings file that will be used throughout this script to
 # avoid repeatedly using sudo.
-readonly TINYPILOT_SETTINGS_FILE="$(mktemp --suffix ".yml")"
+# HACK: If we let mktemp use the default /tmp directory, the system purges the file
+# before the end of the script for some reason. We use /var/tmp as a workaround.
+readonly TINYPILOT_SETTINGS_FILE="$(mktemp --tmpdir="/var/tmp" --suffix ".yml")"
 # Check if there's already a settings file with extra installation settings.
 if [[ -f "${DEFAULT_TINYPILOT_SETTINGS_FILE}" ]]; then
   echo "Using settings file at: ${DEFAULT_TINYPILOT_SETTINGS_FILE}"


### PR DESCRIPTION
Users now need add any extra/custom tinypilot config to a `/home/tinypilot/settings.yml` file.

(This PR is also needed to wrap up the [ansible side of the "Create convenience script for updating uStreamer settings" feature](https://github.com/mtlynch/ansible-role-ustreamer/pull/37#pullrequestreview-621681949))

# Design decisions
1. I had reorder some of the code in the quick-install script in order to check & set variables in the `settings.yml` file.
2. When it comes editing the `settings.yml` file, I kept it simple by using grep to search for variables & echo to append default variables to the yaml file. I foolproof solution would have been to parse the yaml properly and export back to a file, but that would require adding extra dependencies to the project.
3. I wasn't sure what the prefered style is for defining yaml variables. Specifically strings. This is all valid yaml:
    ```yaml
    foo1: bar
    foo2: 'bar'
    foo3: "bar"
    ```
    I went with `foo1`.

# Outstanding changes
1. Update the [wiki](https://github.com/mtlynch/tinypilot/wiki/Installation-Options) telling users to use the settings file instead. This I can do after these changes have been merged seeing as there is no PR system for wiki pages.
2. The `e2e` circleci job is failing. It is complaining about a [non-existent `/home/tinypilot` directory](https://app.circleci.com/pipelines/github/mtlynch/tinypilot/1304/workflows/e871d552-fc12-40e8-979b-819bdc78497c/jobs/4139). This is happening because the quick-install script now tries to create a `/home/tinypilot/settings.yml` file if it doesn't exist in order to set the default ustreamer variables.
To fix this we can either:
    1. let the quick-install fail out when the settings file doesn't exist and ask the user to create one or 
    1. update the docker image build to create a tinypilot home directory. 

Fixes #622

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mtlynch/tinypilot/624)
<!-- Reviewable:end -->
