### PR TITLE
Disable hot reloading by default

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -16,7 +16,7 @@ from find_files import find as find_files
 host = os.environ.get('HOST', '127.0.0.1')
 port = int(os.environ.get('PORT', 8000))
 debug = 'DEBUG' in os.environ
-use_reloader = os.environ.get('USE_RELOADER', '1') == '1'
+use_reloader = os.environ.get('USE_RELOADER', '0') == '1'
 
 root_logger = logging.getLogger()
 handler = logging.StreamHandler()

--- a/dev-scripts/serve-dev
+++ b/dev-scripts/serve-dev
@@ -10,5 +10,10 @@ set -x
 set -u
 
 # Serve TinyPilot in dev mode.
-HOST=0.0.0.0 PORT=8000 KEYBOARD_PATH=/dev/null MOUSE_PATH=/dev/null DEBUG=1 \
+HOST=0.0.0.0 \
+  PORT=8000 \
+  KEYBOARD_PATH=/dev/null \
+  MOUSE_PATH=/dev/null \
+  DEBUG=1 \
+  USE_RELOADER=1 \
   ./app/main.py


### PR DESCRIPTION
I kept it in to facilitate development, but it's generating noise in the logs during updates when TinyPilot tries to reload as files change for the update. Now it's off by default, but the serve-dev script enables it for development.