### PR TITLE
Revert "Upgrade Ansible in installer to 2.10.0"

### DIFF
--- a/quick-install
+++ b/quick-install
@@ -133,20 +133,16 @@ python3 -m venv venv
 . venv/bin/activate
 # For some reason, wheel has to be installed before anything else.
 pip install wheel==0.34.2
-cat > requirements.txt <<EOF
-ansible==2.10.0
-ansible-base==2.10.7
-cffi==1.14.5
+echo 'ansible==2.9.10
+cffi==1.14.4
 cryptography==3.3.1
-Jinja2==2.11.3
+Jinja2==2.11.2
 MarkupSafe==1.1.1
-packaging==20.9
 pkg-resources==0.0.0
 pycparser==2.20
-pyparsing==2.4.7
-PyYAML==5.4.1
-six==1.15.0
-EOF
+pyOpenSSL==20.0.1
+PyYAML==5.3.1
+six==1.15.0' > requirements.txt
 pip install -r requirements.txt
 echo "[defaults]
 roles_path = $PWD


### PR DESCRIPTION
Reverts mtlynch/tinypilot#630

Upgrading to 2.10.0 is actually more complicated than I thought:

https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#upgrading-from-2-9-or-earlier-to-2-10