### PR TITLE
Use HTTP instead of socket.io to detect when an update is complete

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -113,13 +113,6 @@ function onSocketConnect() {
   connectedToServer = true;
   document.getElementById("status-bar").connectionIndicator.connected = true;
   setCursor(settings.getScreenCursor());
-
-  // If we're restarting after an update, mark the update as finished.
-  const updateOverlay = document.getElementById("update-overlay");
-  const updateDialog = document.getElementById("update-dialog");
-  if (updateOverlay.isShown() && updateDialog.state === "restarting") {
-    updateDialog.state = "update-finished";
-  }
 }
 
 function onSocketDisconnect(reason) {

--- a/app/static/js/controllers.js
+++ b/app/static/js/controllers.js
@@ -266,7 +266,7 @@
       });
   }
 
-  function checkStatus(baseURL) {
+  function checkStatus(baseURL = "") {
     const route = "/api/status";
     return fetch(baseURL + route, {
       method: "GET",

--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -211,7 +211,7 @@
           }
         }
 
-        sleep(milliseconds) {
+        _sleep(milliseconds) {
           return new Promise((resolve) => setTimeout(resolve, milliseconds));
         }
 

--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -118,16 +118,16 @@
             });
         }
 
-        get state() {
+        get _state() {
           return this.getAttribute("state");
         }
 
-        set state(newValue) {
+        set _state(newValue) {
           this.setAttribute("state", newValue);
         }
 
         checkVersion() {
-          this.state = "checking";
+          this._state = "checking";
 
           Promise.all([
             controllers.getVersion(),
@@ -138,9 +138,9 @@
               const latestRelease = versions[1];
 
               if (localVersion === latestRelease) {
-                this.state = "latest";
+                this._state = "latest";
               } else {
-                this.state = "update-available";
+                this._state = "update-available";
               }
             })
             .catch((error) => {
@@ -166,11 +166,33 @@
           return controllers
             .shutdown(/*restart*/ true)
             .then(() => {
-              this.state = "restarting";
+              this._state = "restarting";
             })
             .catch((error) => {
               this._handleUpdateFailure({
                 title: "Failed to Restart TinyPilot Device",
+                details: error,
+              });
+            });
+        }
+
+        _waitForReboot() {
+          return poll({
+            fn: () => controllers.checkStatus(),
+            validate: (isUpAndRunning) => isUpAndRunning === true,
+            interval: 3 * 1000,
+            timeout: 180 * 1000,
+          })
+            .then(() => {
+              this._state = "update-finished";
+            })
+            .catch((error) => {
+              this._handleUpdateFailure({
+                title: "Failed to Restart",
+                message:
+                  "Cannot reach TinyPilot after the update. The device" +
+                  "may have failed to reboot. Please try manually resetting " +
+                  "your device's power and trying to connect again.",
                 details: error,
               });
             });
@@ -189,8 +211,12 @@
           }
         }
 
+        sleep(milliseconds) {
+          return new Promise((resolve) => setTimeout(resolve, milliseconds));
+        }
+
         async _doUpdate() {
-          this.state = "updating";
+          this._state = "updating";
           const timer = this.shadowRoot.getElementById("timer");
           timer.start();
 
@@ -209,6 +235,10 @@
             // Updating causes the backend to restart, changing the CSRF token.
             await controllers.refreshCsrfToken();
             await this._performRestart();
+            // Wait at least 10 seconds to ensure reboot has started before
+            // checking whether the system is back up.
+            await this._sleep(10 * 1000);
+            await this._waitForReboot();
           } catch (error) {
             this._handleUpdateFailure({
               title: "Failed to Complete Update",

--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -190,9 +190,9 @@
               this._handleUpdateFailure({
                 title: "Failed to Restart",
                 message:
-                  "Cannot reach TinyPilot after the update. The device" +
-                  "may have failed to reboot. Please try manually resetting " +
-                  "your device's power and trying to connect again.",
+                  "Cannot reach TinyPilot after the update. The device " +
+                  "may have failed to reboot. Please manually reset your " +
+                  "device's power and try to connect again.",
                 details: error,
               });
             });


### PR DESCRIPTION
When we upgraded from socket.io protocol 2 to 3, it broke the check for whether a restart had completed because the frontend was still on protocol 2, and the backend had upgraded to protocol 3. The result was that the update screen spun forever because it was [waiting for onSocketConnect](https://github.com/mtlynch/tinypilot/blob/7a65a6c95d4ad926c041a63685e81981fbdf12f4/app/static/js/app.js#L117L122) to wake up and change the state. But because of the version incompatibility, `onSocketConnect` never executed.

We should rely on regular HTTP to check the status after an update so that we're not vulnerable to this sort of bug in the future.

Fixes #596

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mtlynch/tinypilot/632)
<!-- Reviewable:end -->
