### PR TITLE
Set tinypilot settings file to be world-readable

### DIFF
--- a/quick-install
+++ b/quick-install
@@ -174,5 +174,6 @@ ansible-playbook -i localhost, install.yml \
 
 # Copy the final install settings used in this installation back to the default
 # settings location.
+chmod +r "${TINYPILOT_SETTINGS_FILE}"
 sudo cp "${TINYPILOT_SETTINGS_FILE}" "${DEFAULT_TINYPILOT_SETTINGS_FILE}"
 sudo chown tinypilot:tinypilot "${DEFAULT_TINYPILOT_SETTINGS_FILE}"


### PR DESCRIPTION
By default, creating a file with mktemp makes it rw only to owner. This means that after we chown to tinypilot, the ansible-playbook command (running as standard user) fails because it can't read the previously-created settings.yml file.