### PR TITLE
Refactor update module and add unit tests

### DIFF
--- a/app/update_result_reader.py
+++ b/app/update_result_reader.py
@@ -5,18 +5,73 @@ import iso8601
 import update_result
 import utc
 
+# The update result reader fetches the result of the last update. Because the
+# TinyPilot server holds no state in memory and may be checking the status of an
+# update job just after restarting, it's tricky to identify the result of the
+# update.
+#
+# The happy path of the update is as follows:
+# 1. User initiates an update
+# 2. User queries for update status and the server reports an update is in
+#    progress because it can see the update process running.
+# 3. User repeats (2) for a few minutes until the update completes.
+# 4. At the end of the update, the update process writes an update result file.
+# 5. The next time the user queries for update status, the server reads the
+#    update result file and reports the result of the update based on the file
+#    contents.
+#
+# There are two interesting edge cases we have to handle:
+#
+# 1. The user has initiated an update, but the update process is not yet
+#    running.
+#       TinyPilot will check for a result file, and it may see results from
+#       previous updates, so we have to recognize them as stale and not the
+#       result of the update the user just initiated.
+# 2. The update process crashed without ever writing a result file.
+#       This should be rare, but similarly to (1), we have to make sure we don't
+#       confuse the result of a previous update with the result of an update
+#       that never wrote a result file because it crashed.
+#
+# The update result reader handles these edge cases by reading the timestamp of
+# the update result. For TinyPilot versions < 1.4.1, the timestamp represents
+# the start of the update process. For TinyPilot version >= 1.4.1, the timestamp
+# represents the end of the update process.
+#
+# The result reader has a threshold, before which it assumes result files are
+# from previous update runs (_RECENT_UPDATE_THRESHOLD_SECONDS). The threshold is
+# currently set to eight 8 minutes. That means that the update reader will
+# ignore any result files that are timestamped more than 8 minutes prior to the
+# current time.
+#
+# This solution is brittle because the 8 minutes is arbitrary, and there are
+# still situations where a previous update might be misinterpreted as the
+# current result (e.g., two updates in a row, within 8 minutes).
+#
+# https://github.com/mtlynch/tinypilot/issues/597 tracks the work to replace
+# the update logic with a better solution.
+
+_RESULT_FILE_DIR = os.path.expanduser('~/logs')
+
 # Cutoff under which an update is considered "recently" completed. It should be
 # just long enough that it's the one we see right after a device reboot but not
 # so long that there's risk of it being confused with the result from a later
 # update attempt.
 _RECENT_UPDATE_THRESHOLD_SECONDS = 60 * 8
-_RESULT_FILE_DIR = os.path.expanduser('~/logs')
 
 # Result files are prefixed with UTC timestamps in ISO-8601 format.
 _UPDATE_RESULT_FILENAME_FORMAT = '%s-update-result.json'
 
 
 def read():
+    """Reads the most recent update result, filtering results that are too old.
+
+    Args:
+        None.
+
+    Returns:
+        An update_result.Result based on the most recent update result file
+        within the time threshold or None if none exist.
+    """
     result_files = glob.glob(
         os.path.join(_RESULT_FILE_DIR, _UPDATE_RESULT_FILENAME_FORMAT % '*'))
     if not result_files:

--- a/app/update_result_reader.py
+++ b/app/update_result_reader.py
@@ -1,0 +1,43 @@
+import glob
+import os
+
+import iso8601
+import update_result
+import utc
+
+# Cutoff under which an update is considered "recently" completed. It should be
+# just long enough that it's the one we see right after a device reboot but not
+# so long that there's risk of it being confused with the result from a later
+# update attempt.
+_RECENT_UPDATE_THRESHOLD_SECONDS = 60 * 8
+_RESULT_FILE_DIR = os.path.expanduser('~/logs')
+
+# Result files are prefixed with UTC timestamps in ISO-8601 format.
+_UPDATE_RESULT_FILENAME_FORMAT = '%s-update-result.json'
+
+
+def read():
+    result_files = glob.glob(
+        os.path.join(_RESULT_FILE_DIR, _UPDATE_RESULT_FILENAME_FORMAT % '*'))
+    if not result_files:
+        return None
+
+    # Filenames start with a timestamp, so the last one lexicographically is the
+    # most recently created file.
+    most_recent_result_file = sorted(result_files)[-1]
+    with open(most_recent_result_file) as result_file:
+        most_recent_result = update_result.read(result_file)
+
+    # Ignore the result if it's too old.
+    delta = utc.now() - most_recent_result.timestamp
+    if delta.total_seconds() > _RECENT_UPDATE_THRESHOLD_SECONDS:
+        return None
+
+    return most_recent_result
+
+
+def result_path(timestamp):
+    """Retrieves the associated file path for a result file for a timestamp."""
+    return os.path.join(
+        _RESULT_FILE_DIR,
+        _UPDATE_RESULT_FILENAME_FORMAT % iso8601.to_string(timestamp))

--- a/app/update_result_reader.py
+++ b/app/update_result_reader.py
@@ -1,54 +1,56 @@
+"""Reads result of the most recent TinyPilot update.
+
+The update result reader fetches the result of the last update. Because the
+TinyPilot server holds no state in memory and may be checking the status of an
+update job just after restarting, it's tricky to identify the result of the
+update.
+
+The happy path of the update is as follows:
+1. User initiates an update
+2. User queries for update status and the server reports an update is in
+   progress because it can see the update process running.
+3. User repeats (2) for a few minutes until the update completes.
+4. At the end of the update, the update process writes an update result file.
+5. The next time the user queries for update status, the server reads the
+   update result file and reports the result of the update based on the file
+   contents.
+
+There are two interesting edge cases we have to handle:
+
+1. The user has initiated an update, but the update process is not yet running.
+     TinyPilot will check for a result file, and it may see results from
+     previous updates, so we have to recognize them as stale and not the result
+     of the update the user just initiated.
+2. The update process crashed without ever writing a result file.
+      This should be rare, but similarly to (1), we have to make sure we don't
+      confuse the result of a previous update with the result of an update that
+      never wrote a result file because it crashed.
+
+The update result reader handles these edge cases by reading the timestamp of
+the update result. For TinyPilot versions < 1.4.1, the timestamp represents the
+start of the update process. For TinyPilot version >= 1.4.1, the timestamp
+represents the end of the update process.
+
+The result reader has a threshold, before which it assumes result files are from
+previous update runs (_RECENT_UPDATE_THRESHOLD_SECONDS). The threshold is
+currently set to eight 8 minutes. That means that the update reader will ignore
+any result files that are timestamped more than 8 minutes prior to the current
+time.
+
+This solution is brittle because the 8 minutes is arbitrary, and there are still
+situations where a previous update might be misinterpreted as the current result
+(e.g., two updates in a row, within 8 minutes).
+
+https://github.com/mtlynch/tinypilot/issues/597 tracks the work to replace the
+update logic with a better solution.
+"""
+
 import glob
 import os
 
 import iso8601
 import update_result
 import utc
-
-# The update result reader fetches the result of the last update. Because the
-# TinyPilot server holds no state in memory and may be checking the status of an
-# update job just after restarting, it's tricky to identify the result of the
-# update.
-#
-# The happy path of the update is as follows:
-# 1. User initiates an update
-# 2. User queries for update status and the server reports an update is in
-#    progress because it can see the update process running.
-# 3. User repeats (2) for a few minutes until the update completes.
-# 4. At the end of the update, the update process writes an update result file.
-# 5. The next time the user queries for update status, the server reads the
-#    update result file and reports the result of the update based on the file
-#    contents.
-#
-# There are two interesting edge cases we have to handle:
-#
-# 1. The user has initiated an update, but the update process is not yet
-#    running.
-#       TinyPilot will check for a result file, and it may see results from
-#       previous updates, so we have to recognize them as stale and not the
-#       result of the update the user just initiated.
-# 2. The update process crashed without ever writing a result file.
-#       This should be rare, but similarly to (1), we have to make sure we don't
-#       confuse the result of a previous update with the result of an update
-#       that never wrote a result file because it crashed.
-#
-# The update result reader handles these edge cases by reading the timestamp of
-# the update result. For TinyPilot versions < 1.4.1, the timestamp represents
-# the start of the update process. For TinyPilot version >= 1.4.1, the timestamp
-# represents the end of the update process.
-#
-# The result reader has a threshold, before which it assumes result files are
-# from previous update runs (_RECENT_UPDATE_THRESHOLD_SECONDS). The threshold is
-# currently set to eight 8 minutes. That means that the update reader will
-# ignore any result files that are timestamped more than 8 minutes prior to the
-# current time.
-#
-# This solution is brittle because the 8 minutes is arbitrary, and there are
-# still situations where a previous update might be misinterpreted as the
-# current result (e.g., two updates in a row, within 8 minutes).
-#
-# https://github.com/mtlynch/tinypilot/issues/597 tracks the work to replace
-# the update logic with a better solution.
 
 _RESULT_FILE_DIR = os.path.expanduser('~/logs')
 

--- a/app/update_result_reader.py
+++ b/app/update_result_reader.py
@@ -22,9 +22,9 @@ There are two interesting edge cases we have to handle:
      previous updates, so we have to recognize them as stale and not the result
      of the update the user just initiated.
 2. The update process crashed without ever writing a result file.
-      This should be rare, but similarly to (1), we have to make sure we don't
-      confuse the result of a previous update with the result of an update that
-      never wrote a result file because it crashed.
+     This should be rare, but similarly to (1), we have to make sure we don't
+     confuse the result of a previous update with the result of an update that
+     never wrote a result file because it crashed.
 
 The update result reader handles these edge cases by reading the timestamp of
 the update result. For TinyPilot versions < 1.4.1, the timestamp represents the

--- a/app/update_result_reader_test.py
+++ b/app/update_result_reader_test.py
@@ -47,6 +47,14 @@ class UpdateResultReaderTest(unittest.TestCase):
   "error": "",
   "timestamp": "2021-01-01T000000Z"
 }
+            """),
+            self.make_mock_file(
+                '2021-01-01T000300Z-update-result.json', """
+{
+  "success": true,
+  "error": "",
+  "timestamp": "2021-01-01T000300Z"
+}
             """)
         ]
         mock_now.return_value = datetime.datetime(2021,
@@ -64,7 +72,7 @@ class UpdateResultReaderTest(unittest.TestCase):
                                      1,
                                      1,
                                      0,
-                                     0,
+                                     3,
                                      0,
                                      tzinfo=datetime.timezone.utc)),
             update_result_reader.read())

--- a/app/update_result_reader_test.py
+++ b/app/update_result_reader_test.py
@@ -33,7 +33,7 @@ class UpdateResultReaderTest(unittest.TestCase):
             self, mock_now, mock_glob):
         mock_glob.return_value = [
             self.make_mock_file(
-                'foo.json', """
+                '2020-12-31T000000Z-update-result.json', """
 {
   "success": true,
   "error": "",
@@ -41,7 +41,7 @@ class UpdateResultReaderTest(unittest.TestCase):
 }
             """),
             self.make_mock_file(
-                'foo.json', """
+                '2021-01-01T000000Z-update-result.json', """
 {
   "success": true,
   "error": "",
@@ -75,7 +75,7 @@ class UpdateResultReaderTest(unittest.TestCase):
             self, mock_now, mock_glob):
         mock_glob.return_value = [
             self.make_mock_file(
-                'foo.json', """
+                '2021-01-01T000000Z', """
 {
   "success": true,
   "error": "",

--- a/app/update_result_reader_test.py
+++ b/app/update_result_reader_test.py
@@ -1,0 +1,61 @@
+import datetime
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+import update_result
+import update_result_reader
+
+
+class UpdateResultReaderTest(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_result_dir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.mock_result_dir.cleanup()
+
+    def make_mock_file(self, filename, contents):
+        full_path = os.path.join(self.mock_result_dir.name, filename)
+        with open(full_path, 'w') as mock_file:
+            mock_file.write(contents)
+        return full_path
+
+    @mock.patch.object(update_result_reader.glob, 'glob')
+    def test_returns_none_when_no_result_files_exist(self, mock_glob):
+        mock_glob.return_value = []
+        self.assertIsNone(update_result_reader.read())
+
+    @mock.patch.object(update_result_reader.glob, 'glob')
+    @mock.patch.object(update_result_reader.utc, 'now')
+    def test_returns_latest(self, mock_now, mock_glob):
+        mock_glob.return_value = [
+            self.make_mock_file(
+                'foo.json', """
+{
+  "success": true,
+  "error": "",
+  "timestamp": "2021-02-10T085735Z"
+}
+            """)
+        ]
+        mock_now.return_value = datetime.datetime(2021,
+                                                  2,
+                                                  10,
+                                                  8,
+                                                  57,
+                                                  36,
+                                                  tzinfo=datetime.timezone.utc)
+        self.assertEqual(
+            update_result.Result(success=True,
+                                 error='',
+                                 timestamp=datetime.datetime(
+                                     2021,
+                                     2,
+                                     10,
+                                     8,
+                                     57,
+                                     35,
+                                     tzinfo=datetime.timezone.utc)),
+            update_result_reader.read())

--- a/app/update_test.py
+++ b/app/update_test.py
@@ -1,0 +1,92 @@
+import unittest
+from unittest import mock
+
+import update
+import update_result
+
+
+class UpdateTest(unittest.TestCase):
+
+    @mock.patch.object(update.subprocess, 'check_output')
+    @mock.patch.object(update.update_result_reader, 'read')
+    def test_returns_not_running_when_there_is_no_process_nor_result_file(
+            self, mock_read_update_result, mock_check_output):
+        mock_check_output.return_value = """
+USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+root         1  0.0  0.0 224928  8612 ?        Ss   Apr03   0:01 /sbin/dummy-a
+root        51  0.0  0.0 103152 21264 ?        Ss   Apr03   0:00 /lib/dummy-b
+""".lstrip().encode('utf-8')
+        mock_read_update_result.return_value = None
+
+        status_actual, error_actual = update.get_current_state()
+        self.assertEqual(update.Status.NOT_RUNNING, status_actual)
+        self.assertIsNone(error_actual)
+
+    @mock.patch.object(update.subprocess, 'check_output')
+    @mock.patch.object(update.update_result_reader, 'read')
+    def test_returns_running_when_update_process_is_running(
+            self, mock_read_update_result, mock_check_output):
+        mock_check_output.return_value = """
+USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+root         1  0.0  0.0 224928  8612 ?        Ss   Apr03   0:01 /sbin/dummy-a
+root        51  0.0  0.0 103152 21264 ?        Ss   Apr03   0:00 /opt/tinypilot-privileged/update
+""".lstrip().encode('utf-8')
+        mock_read_update_result.return_value = None
+
+        status_actual, error_actual = update.get_current_state()
+        self.assertEqual(update.Status.IN_PROGRESS, status_actual)
+        self.assertIsNone(error_actual)
+
+    @mock.patch.object(update.subprocess, 'check_output')
+    @mock.patch.object(update.update_result_reader, 'read')
+    def test_ignores_update_result_if_update_is_running(self,
+                                                        mock_read_update_result,
+                                                        mock_check_output):
+        """If update is running, last update result does not matter."""
+        mock_check_output.return_value = """
+USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+root         1  0.0  0.0 224928  8612 ?        Ss   Apr03   0:01 /sbin/dummy-a
+root        51  0.0  0.0 103152 21264 ?        Ss   Apr03   0:00 /opt/tinypilot-privileged/update
+""".lstrip().encode('utf-8')
+        # get_current_state should ignore this result because an update process
+        # is currently running, which takes priority over the previous result.
+        mock_read_update_result.return_value = update_result.Result(
+            success=True, error=None, timestamp='2021-02-10T085735Z')
+
+        status_actual, error_actual = update.get_current_state()
+        self.assertEqual(update.Status.IN_PROGRESS, status_actual)
+        self.assertIsNone(error_actual)
+
+    @mock.patch.object(update.subprocess, 'check_output')
+    @mock.patch.object(update.update_result_reader, 'read')
+    def test_returns_success_when_no_process_is_running_and_last_run_was_ok(
+            self, mock_read_update_result, mock_check_output):
+        mock_check_output.return_value = """
+USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+root         1  0.0  0.0 224928  8612 ?        Ss   Apr03   0:01 /sbin/dummy-a
+root        51  0.0  0.0 103152 21264 ?        Ss   Apr03   0:00 /lib/dummy-b
+""".lstrip().encode('utf-8')
+        mock_read_update_result.return_value = update_result.Result(
+            success=True, error=None, timestamp='2021-02-10T085735Z')
+
+        status_actual, error_actual = update.get_current_state()
+        self.assertEqual(update.Status.DONE, status_actual)
+        self.assertIsNone(error_actual)
+
+    @mock.patch.object(update.subprocess, 'check_output')
+    @mock.patch.object(update.update_result_reader, 'read')
+    def test_returns_error_when_no_process_is_running_and_last_run_had_error(
+            self, mock_read_update_result, mock_check_output):
+        mock_check_output.return_value = """
+USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+root         1  0.0  0.0 224928  8612 ?        Ss   Apr03   0:01 /sbin/dummy-a
+root        51  0.0  0.0 103152 21264 ?        Ss   Apr03   0:00 /lib/dummy-b
+""".lstrip().encode('utf-8')
+        mock_read_update_result.return_value = update_result.Result(
+            success=False,
+            error='dummy update error',
+            timestamp='2021-02-10T085735Z')
+
+        status_actual, error_actual = update.get_current_state()
+        self.assertEqual(update.Status.DONE, status_actual)
+        self.assertEqual('dummy update error', error_actual)

--- a/app/update_test.py
+++ b/app/update_test.py
@@ -24,7 +24,7 @@ root        51  0.0  0.0 103152 21264 ?        Ss   Apr03   0:00 /lib/dummy-b
 
     @mock.patch.object(update.subprocess, 'check_output')
     @mock.patch.object(update.update_result_reader, 'read')
-    def test_returns_running_when_update_process_is_running(
+    def test_returns_in_progress_when_update_process_is_running(
             self, mock_read_update_result, mock_check_output):
         mock_check_output.return_value = """
 USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND

--- a/scripts/update-service
+++ b/scripts/update-service
@@ -12,6 +12,7 @@ import subprocess
 
 import update
 import update_result
+import update_result_reader
 import utc
 
 logger = logging.getLogger(__name__)
@@ -57,7 +58,7 @@ def run_update_script():
 
 
 def write_result(result):
-    result_path = update.get_result_path(result.timestamp)
+    result_path = update_result_reader.get_result_path(result.timestamp)
     os.makedirs(os.path.dirname(result_path), exist_ok=True)
     with open(result_path, 'w') as result_file:
         logger.info('Writing result file to %s', result_path)


### PR DESCRIPTION
This refactors the update module to make it simpler, more testable, and better documented. This *should* be a pure refactoring that preserves all existing behavior.

The update component is important because failed updates are an especially poor user experience. There were previously no automated tests because of the difficulty of testing update logic, but I've broken up the module to mock out dependencies that were obstructing testing.

I'm planning to simplify the logic in a future PR (see #597), but I wanted to first create tests to lock in the existing behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mtlynch/tinypilot/636)
<!-- Reviewable:end -->
