### PR TITLE
Remove generic except block

### DIFF
--- a/app/hostname.py
+++ b/app/hostname.py
@@ -48,5 +48,3 @@ def change(new_hostname):
             universal_newlines=True)
     except subprocess.CalledProcessError as e:
         raise HostnameChangeError(str(e.output).strip()) from e
-    except Exception as e:
-        raise HostnameChangeError(str(e)) from e


### PR DESCRIPTION
The generic except block was introduced in https://github.com/mtlynch/tinypilot/pull/504, because a) Flask didn’t handle unhandled exceptions gracefully and b) we didn’t have the mock scripts yet. Both is obsolete by now, so it can eventually go away.

(I probably should have put a `todo` in the code… 👀 )

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mtlynch/tinypilot/637)
<!-- Reviewable:end -->
