### PR TITLE
Remove success member from update_result.Result

### DIFF
--- a/app/update_result.py
+++ b/app/update_result.py
@@ -7,8 +7,10 @@ import iso8601
 
 @dataclasses.dataclass
 class Result:
-    success: bool
+    # The error message for a failed update. An empty string implies that the
+    # update succeeded.
     error: str
+    # Time at which the update completed.
     timestamp: datetime.datetime
 
 
@@ -19,7 +21,6 @@ def read(result_file):
     have a format like:
 
       {
-        "success": true,
         "error": "",
         "timestamp": "2021-02-10T085735Z",
       }
@@ -31,8 +32,7 @@ def read(result_file):
         A Result object parsed from the file.
     """
     raw_result = json.load(result_file, cls=_ResultDecoder)
-    return Result(success=raw_result.get('success', False),
-                  error=raw_result.get('error', ''),
+    return Result(error=raw_result.get('error', ''),
                   timestamp=raw_result.get(
                       'timestamp', datetime.datetime.utcfromtimestamp(0)))
 

--- a/app/update_result_reader_test.py
+++ b/app/update_result_reader_test.py
@@ -35,7 +35,6 @@ class UpdateResultReaderTest(unittest.TestCase):
             self.make_mock_file(
                 '2020-12-31T000000Z-update-result.json', """
 {
-  "success": true,
   "error": "",
   "timestamp": "2020-12-31T000000Z"
 }
@@ -43,7 +42,6 @@ class UpdateResultReaderTest(unittest.TestCase):
             self.make_mock_file(
                 '2021-01-01T000000Z-update-result.json', """
 {
-  "success": true,
   "error": "",
   "timestamp": "2021-01-01T000000Z"
 }
@@ -51,7 +49,6 @@ class UpdateResultReaderTest(unittest.TestCase):
             self.make_mock_file(
                 '2021-01-01T000300Z-update-result.json', """
 {
-  "success": true,
   "error": "",
   "timestamp": "2021-01-01T000300Z"
 }
@@ -84,7 +81,6 @@ class UpdateResultReaderTest(unittest.TestCase):
             self.make_mock_file(
                 '2021-01-01T000000Z-update-result.json', """
 {
-  "success": true,
   "error": "",
   "timestamp": "2021-01-01T000000Z"
 }
@@ -92,7 +88,6 @@ class UpdateResultReaderTest(unittest.TestCase):
             self.make_mock_file(
                 '2021-01-01T000300Z-update-result.json', """
 {
-  "success": true,
   "error": "",
   "timestamp": "2021-01-01T000300Z"
 }
@@ -100,7 +95,6 @@ class UpdateResultReaderTest(unittest.TestCase):
             self.make_mock_file(
                 '2021-01-01T000600Z-update-result.json', """
 {
-  "success": true,
   "error": "",
   "timestamp": "2021-01-01T000600Z"
 }
@@ -135,7 +129,6 @@ class UpdateResultReaderTest(unittest.TestCase):
             self.make_mock_file(
                 '2021-01-01T000000Z', """
 {
-  "success": true,
   "error": "",
   "timestamp": "2021-01-01T000000Z"
 }

--- a/app/update_result_reader_test.py
+++ b/app/update_result_reader_test.py
@@ -65,8 +65,7 @@ class UpdateResultReaderTest(unittest.TestCase):
                                                   second=0,
                                                   tzinfo=datetime.timezone.utc)
         self.assertEqual(
-            update_result.Result(success=True,
-                                 error='',
+            update_result.Result(error='',
                                  timestamp=datetime.datetime(
                                      year=2021,
                                      month=1,
@@ -117,8 +116,7 @@ class UpdateResultReaderTest(unittest.TestCase):
                                                   second=0,
                                                   tzinfo=datetime.timezone.utc)
         self.assertEqual(
-            update_result.Result(success=True,
-                                 error='',
+            update_result.Result(error='',
                                  timestamp=datetime.datetime(
                                      year=2021,
                                      month=1,

--- a/app/update_result_test.py
+++ b/app/update_result_test.py
@@ -67,8 +67,7 @@ class UpdateResultTest(unittest.TestCase):
                                             35,
                                             tzinfo=datetime.timezone.utc),
             ), mock_file)
-        self.assertEqual(('{"error": "", '
-                          '"timestamp": "2021-02-10T085735Z"}'),
+        self.assertEqual(('{"error": "", "timestamp": "2021-02-10T085735Z"}'),
                          mock_file.getvalue())
 
     def test_writes_error_result_accurately(self):

--- a/app/update_result_test.py
+++ b/app/update_result_test.py
@@ -7,10 +7,9 @@ import update_result
 
 class UpdateResultTest(unittest.TestCase):
 
-    def test_reads_correct_values_for_successful_result(self):
+    def test_returns_none_when_no_result_files_exist(self):
         self.assertEqual(
             update_result.Result(
-                success=True,
                 error='',
                 timestamp=datetime.datetime(2021,
                                             2,
@@ -23,7 +22,6 @@ class UpdateResultTest(unittest.TestCase):
             update_result.read(
                 io.StringIO("""
 {
-  "success": true,
   "error": "",
   "timestamp": "2021-02-10T085735Z"
 }
@@ -32,7 +30,6 @@ class UpdateResultTest(unittest.TestCase):
     def test_reads_correct_values_for_failed_result(self):
         self.assertEqual(
             update_result.Result(
-                success=False,
                 error='dummy update error',
                 timestamp=datetime.datetime(2021,
                                             2,
@@ -45,7 +42,6 @@ class UpdateResultTest(unittest.TestCase):
             update_result.read(
                 io.StringIO("""
 {
-  "success": false,
   "error": "dummy update error",
   "timestamp": "2021-02-10T085735Z"
 }
@@ -54,7 +50,6 @@ class UpdateResultTest(unittest.TestCase):
     def test_reads_default_values_for_empty_dict(self):
         self.assertEqual(
             update_result.Result(
-                success=False,
                 error='',
                 timestamp=datetime.datetime.utcfromtimestamp(0),
             ), update_result.read(io.StringIO('{}')))
@@ -63,7 +58,6 @@ class UpdateResultTest(unittest.TestCase):
         mock_file = io.StringIO()
         update_result.write(
             update_result.Result(
-                success=True,
                 error='',
                 timestamp=datetime.datetime(2021,
                                             2,
@@ -73,7 +67,7 @@ class UpdateResultTest(unittest.TestCase):
                                             35,
                                             tzinfo=datetime.timezone.utc),
             ), mock_file)
-        self.assertEqual(('{"success": true, "error": "", '
+        self.assertEqual(('{"error": "", '
                           '"timestamp": "2021-02-10T085735Z"}'),
                          mock_file.getvalue())
 
@@ -81,7 +75,6 @@ class UpdateResultTest(unittest.TestCase):
         mock_file = io.StringIO()
         update_result.write(
             update_result.Result(
-                success=False,
                 error='dummy update error',
                 timestamp=datetime.datetime(2021,
                                             2,
@@ -91,6 +84,6 @@ class UpdateResultTest(unittest.TestCase):
                                             35,
                                             tzinfo=datetime.timezone.utc),
             ), mock_file)
-        self.assertEqual(('{"success": false, "error": "dummy update error", '
+        self.assertEqual(('{"error": "dummy update error", '
                           '"timestamp": "2021-02-10T085735Z"}'),
                          mock_file.getvalue())

--- a/app/update_result_test.py
+++ b/app/update_result_test.py
@@ -7,7 +7,7 @@ import update_result
 
 class UpdateResultTest(unittest.TestCase):
 
-    def test_returns_none_when_no_result_files_exist(self):
+    def test_reads_correct_values_for_successful_result(self):
         self.assertEqual(
             update_result.Result(
                 error='',

--- a/app/update_test.py
+++ b/app/update_test.py
@@ -51,7 +51,7 @@ root        51  0.0  0.0 103152 21264 ?        Ss   Apr03   0:00 /opt/tinypilot-
         # get_current_state should ignore this result because an update process
         # is currently running, which takes priority over the previous result.
         mock_read_update_result.return_value = update_result.Result(
-            success=True, error=None, timestamp='2021-02-10T085735Z')
+            error=None, timestamp='2021-02-10T085735Z')
 
         status_actual, error_actual = update.get_current_state()
         self.assertEqual(update.Status.IN_PROGRESS, status_actual)
@@ -67,7 +67,7 @@ root         1  0.0  0.0 224928  8612 ?        Ss   Apr03   0:01 /sbin/dummy-a
 root        51  0.0  0.0 103152 21264 ?        Ss   Apr03   0:00 /lib/dummy-b
 """.lstrip().encode('utf-8')
         mock_read_update_result.return_value = update_result.Result(
-            success=True, error=None, timestamp='2021-02-10T085735Z')
+            error=None, timestamp='2021-02-10T085735Z')
 
         status_actual, error_actual = update.get_current_state()
         self.assertEqual(update.Status.DONE, status_actual)
@@ -83,9 +83,7 @@ root         1  0.0  0.0 224928  8612 ?        Ss   Apr03   0:01 /sbin/dummy-a
 root        51  0.0  0.0 103152 21264 ?        Ss   Apr03   0:00 /lib/dummy-b
 """.lstrip().encode('utf-8')
         mock_read_update_result.return_value = update_result.Result(
-            success=False,
-            error='dummy update error',
-            timestamp='2021-02-10T085735Z')
+            error='dummy update error', timestamp='2021-02-10T085735Z')
 
         status_actual, error_actual = update.get_current_state()
         self.assertEqual(update.Status.DONE, status_actual)

--- a/scripts/update-service
+++ b/scripts/update-service
@@ -5,6 +5,7 @@
 # launched manually when the user requests an update.
 
 import argparse
+import datetime
 import logging
 import os
 import subprocess
@@ -36,14 +37,15 @@ def perform_update():
 
 
 def run_update_script():
-    result = update_result.Result(success=False, error='', timestamp=utc.now())
+    result = update_result.Result(
+        error='The update did not complete',
+        timestamp=datetime.datetime.utcfromtimestamp(0))
     try:
         logger.info('Launching update script: %s', update.UPDATE_SCRIPT_PATH)
         subprocess.run(['sudo', update.UPDATE_SCRIPT_PATH],
                        check=True,
                        timeout=_UPDATE_TIMEOUT_SECONDS)
         logger.info('Update completed successfully')
-        result.success = True
     except subprocess.TimeoutExpired:
         logger.error('Update process timed out')
         result.error = 'The update timed out'


### PR DESCRIPTION
We never read the field in produciton code, so it's just adding extra complexity. It's better to just assume that empty error string == success.