### PR TITLE
Make system menu options more concise

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ To update to the latest version of TinyPilot, run the update script:
 
 ## Diagnostics
 
-If you're having trouble with TinyPilot, you can retrive logs from the web dashboard by clicking "View Logs" in the bottom of the main dashboard.
+If you're having trouble with TinyPilot, you can retrive logs from the web dashboard by clicking "Logs" in the bottom of the main dashboard.
 
 If you can't access the web dashboard, you can retrieve the logs by SSHing into the device and running the following command:
 

--- a/app/templates/custom-elements/menubar.html
+++ b/app/templates/custom-elements/menubar.html
@@ -178,10 +178,10 @@
           <a id="update-btn">Update</a>
         </li>
         <li class="item">
-          <a id="change-hostname-btn">Change hostname</a>
+          <a id="change-hostname-btn">Hostname</a>
         </li>
         <li class="item">
-          <a id="debug-dialog-btn">View Logs</a>
+          <a id="debug-dialog-btn">Logs</a>
         </li>
         <li class="item">
           <a id="power-btn">Power</a>


### PR DESCRIPTION
We don't need to say 'change hostname' or 'view logs' because it's assumed that the user will be able to manage them.