### PR TITLE
Change semantics of update settings module

### DIFF
--- a/app/update/settings.py
+++ b/app/update/settings.py
@@ -1,8 +1,9 @@
 """Manages a TinyPilot update settings file.
 
-TinyPilot currently manages most settings through Ansible, and Ansible loads
-this settings file to control certain properties of the TinyPilot install and
-configuration.
+TinyPilot currently manages most settings through Ansible. When TinyPilot
+launches ansible, it passes an extra YAML file that controls properties of the
+install and configuration. This module is a wrapper around the YAML file that
+allows TinyPilot code to modify it cleanly.
 
 Typical usage example:
 
@@ -45,7 +46,17 @@ class Settings:
 
 
 def load():
-    """Gets the current Settings object from the TinyPilot settings file."""
+    """Retrieves the current TinyPilot update settings
+
+    Parses the contents of settings file and generates a settings object that
+    represents the values in the settings file.
+
+    Args:
+        None
+
+    Returns:
+        A Settings instance of the current update settings.
+    """
     try:
         with open(_settings_file_path()) as settings_file:
             print('opened %s' % _settings_file_path())
@@ -61,22 +72,11 @@ def save(settings):
 
 
 def _from_file(settings_file):
-    """Creates a settings instance to manage the TinyPilot settings file.
-
-    Parses the contents of settings file and generates a settings object that
-    represents the values in the settings file.
-
-    Args:
-        settings_file: File containing TinyPilot settings in YAML format.
-
-    Returns:
-        An object containing TinyPilot settings.
-    """
     return Settings(yaml.safe_load(settings_file))
 
 
 def _to_file(settings, settings_file):
-    """Writes the current settings to the settings file."""
+    """Writes a Settings object to a file."""
     if settings.as_dict():
         yaml.safe_dump(settings.as_dict(), settings_file)
 

--- a/app/update/settings.py
+++ b/app/update/settings.py
@@ -59,7 +59,6 @@ def load():
     """
     try:
         with open(_settings_file_path()) as settings_file:
-            print('opened %s' % _settings_file_path())
             return _from_file(settings_file)
     except FileNotFoundError:
         return Settings(data=None)

--- a/app/update/settings_test.py
+++ b/app/update/settings_test.py
@@ -1,61 +1,86 @@
-import io
+import os.path
+import tempfile
 import unittest
+from unittest import mock
 
 import update.settings
 
 
 class UpdateSettingsTest(unittest.TestCase):
 
-    def test_populates_empty_file_blank_settings(self):
-        mock_input_file = io.StringIO()
-        mock_output_file = io.StringIO()
+    def setUp(self):
+        # Mock out the path to the settings.yml file so that it points to a file
+        # path that the test controls.
+        self.mock_settings_dir = tempfile.TemporaryDirectory()
+        self.settings_file_path = os.path.join(self.mock_settings_dir.name,
+                                               'settings.yml')
 
-        settings = update.settings.load(mock_input_file)
-        update.settings.save(settings, mock_output_file)
+        expanduser_patch = mock.patch.object(update.settings.os.path,
+                                             'expanduser')
+        self.addCleanup(expanduser_patch.stop)
+        mock_expanduser = expanduser_patch.start()
+        mock_expanduser.return_value = self.settings_file_path
 
-        self.assertEqual('', mock_output_file.getvalue())
+    def tearDown(self):
+        self.mock_settings_dir.cleanup()
+
+    def make_mock_settings_file(self, contents):
+        with open(self.settings_file_path, 'w') as mock_file:
+            mock_file.write(contents)
+
+    def read_mock_settings_file(self):
+        with open(self.settings_file_path) as mock_file:
+            return mock_file.read()
+
+    def test_returns_empty_settings_if_no_settings_file_exists(self):
+        self.assertEqual({}, update.settings.load().as_dict())
+
+    def test_populates_empty_file_with_blank_settings(self):
+        self.make_mock_settings_file('')
+
+        settings = update.settings.load()
+        update.settings.save(settings)
+
+        self.assertEqual('', self.read_mock_settings_file())
 
     def test_populates_empty_file_with_branch_name(self):
-        mock_input_file = io.StringIO()
-        mock_output_file = io.StringIO()
+        self.make_mock_settings_file('')
 
-        settings = update.settings.load(mock_input_file)
+        settings = update.settings.load()
         settings.tinypilot_repo_branch = 'dummy-branch-name'
-        update.settings.save(settings, mock_output_file)
+        update.settings.save(settings)
 
         self.assertMultiLineEqual(
             """
 tinypilot_repo_branch: dummy-branch-name
-""".lstrip(), mock_output_file.getvalue())
+""".lstrip(), self.read_mock_settings_file())
 
     def test_overwrites_existing_branch_name(self):
-        mock_input_file = io.StringIO("""
+        self.make_mock_settings_file("""
 tinypilot_repo_branch: branch-name-to-overwrite
 """.lstrip())
-        mock_output_file = io.StringIO()
 
-        settings = update.settings.load(mock_input_file)
+        settings = update.settings.load()
         settings.tinypilot_repo_branch = 'dummy-branch-name'
-        update.settings.save(settings, mock_output_file)
+        update.settings.save(settings)
 
         self.assertMultiLineEqual(
             """
 tinypilot_repo_branch: dummy-branch-name
-""".lstrip(), mock_output_file.getvalue())
+""".lstrip(), self.read_mock_settings_file())
 
     def test_leaves_unrecognized_settings_intact(self):
-        mock_input_file = io.StringIO("""
+        self.make_mock_settings_file("""
 tinypilot_repo_branch: branch-name-to-overwrite
 unrecognized_setting: dummyvalue
 """.lstrip())
-        mock_output_file = io.StringIO()
 
-        settings = update.settings.load(mock_input_file)
+        settings = update.settings.load()
         settings.tinypilot_repo_branch = 'dummy-branch-name'
-        update.settings.save(settings, mock_output_file)
+        update.settings.save(settings)
 
         self.assertMultiLineEqual(
             """
 tinypilot_repo_branch: dummy-branch-name
 unrecognized_setting: dummyvalue
-""".lstrip(), mock_output_file.getvalue())
+""".lstrip(), self.read_mock_settings_file())


### PR DESCRIPTION
The update settings module had confusing naming and was awkward for callers to use because they had to directly open the settings file and pass it to the module. It wasn't so bad when there was just one caller, but it looks like we'll potentially have many callers, so it makes sense to make the calling semantics easier and more obvious.

Before: Callers were responsible for opening the update settings file and passing the file handle.
After: The settings module is responsible for managing the file handle. Callers don't have to know where the file is located.

Fixes #650