### PR TITLE
Clarify method call to parse_message

### DIFF
--- a/app/request_parsers/hostname.py
+++ b/app/request_parsers/hostname.py
@@ -4,7 +4,8 @@ from request_parsers.validators import hostname as hostname_validator
 
 
 def parse_hostname(request):
-    message = message_parser.parse_message(request, ['hostname'])
+    message = message_parser.parse_message(request,
+                                           required_fields=['hostname'])
     hostname = message['hostname']
     if not hostname_validator.validate(hostname):
         raise errors.InvalidHostnameError(


### PR DESCRIPTION
I realized I just read the call to it and couldn't remember what the parameter meant without jumping to the function definition. We should make it obvious from the callsite.