### PR TITLE
Use error=None to represent update success

### DIFF
--- a/app/update/result.py
+++ b/app/update/result.py
@@ -7,8 +7,8 @@ import iso8601
 
 @dataclasses.dataclass
 class Result:
-    # The error message for a failed update. An empty string implies that the
-    # update succeeded.
+    # The error message for a failed update. A value of None implies the update
+    # succeeded.
     error: str
     # Time at which the update completed.
     timestamp: datetime.datetime
@@ -21,7 +21,7 @@ def read(result_file):
     have a format like:
 
       {
-        "error": "",
+        "error": null,
         "timestamp": "2021-02-10T085735Z",
       }
 
@@ -32,7 +32,10 @@ def read(result_file):
         A Result object parsed from the file.
     """
     raw_result = json.load(result_file, cls=_ResultDecoder)
-    return Result(error=raw_result.get('error', ''),
+    error = raw_result.get('error', None)
+    if error == '':
+        error = None
+    return Result(error=error,
                   timestamp=raw_result.get(
                       'timestamp', datetime.datetime.utcfromtimestamp(0)))
 

--- a/app/update/result_reader_test.py
+++ b/app/update/result_reader_test.py
@@ -35,21 +35,21 @@ class UpdateResultReaderTest(unittest.TestCase):
             self.make_mock_file(
                 '2020-12-31T000000Z-update-result.json', """
 {
-  "error": "",
+  "error": null,
   "timestamp": "2020-12-31T000000Z"
 }
             """),
             self.make_mock_file(
                 '2021-01-01T000000Z-update-result.json', """
 {
-  "error": "",
+  "error": null,
   "timestamp": "2021-01-01T000000Z"
 }
             """),
             self.make_mock_file(
                 '2021-01-01T000300Z-update-result.json', """
 {
-  "error": "",
+  "error": null,
   "timestamp": "2021-01-01T000300Z"
 }
             """)
@@ -62,7 +62,7 @@ class UpdateResultReaderTest(unittest.TestCase):
                                                   second=0,
                                                   tzinfo=datetime.timezone.utc)
         self.assertEqual(
-            update.result.Result(error='',
+            update.result.Result(error=None,
                                  timestamp=datetime.datetime(
                                      year=2021,
                                      month=1,
@@ -81,21 +81,21 @@ class UpdateResultReaderTest(unittest.TestCase):
             self.make_mock_file(
                 '2021-01-01T000000Z-update-result.json', """
 {
-  "error": "",
+  "error": null,
   "timestamp": "2021-01-01T000000Z"
 }
             """),
             self.make_mock_file(
                 '2021-01-01T000300Z-update-result.json', """
 {
-  "error": "",
+  "error": null,
   "timestamp": "2021-01-01T000300Z"
 }
             """),
             self.make_mock_file(
                 '2021-01-01T000600Z-update-result.json', """
 {
-  "error": "",
+  "error": null,
   "timestamp": "2021-01-01T000600Z"
 }
             """)
@@ -110,7 +110,7 @@ class UpdateResultReaderTest(unittest.TestCase):
                                                   second=0,
                                                   tzinfo=datetime.timezone.utc)
         self.assertEqual(
-            update.result.Result(error='',
+            update.result.Result(error=None,
                                  timestamp=datetime.datetime(
                                      year=2021,
                                      month=1,
@@ -129,7 +129,7 @@ class UpdateResultReaderTest(unittest.TestCase):
             self.make_mock_file(
                 '2021-01-01T000000Z', """
 {
-  "error": "",
+  "error": null,
   "timestamp": "2021-01-01T000000Z"
 }
             """)

--- a/app/update/result_test.py
+++ b/app/update/result_test.py
@@ -10,7 +10,7 @@ class UpdateResultTest(unittest.TestCase):
     def test_reads_correct_values_for_successful_result(self):
         self.assertEqual(
             update.result.Result(
-                error='',
+                error=None,
                 timestamp=datetime.datetime(2021,
                                             2,
                                             10,
@@ -22,7 +22,7 @@ class UpdateResultTest(unittest.TestCase):
             update.result.read(
                 io.StringIO("""
 {
-  "error": "",
+  "error": null,
   "timestamp": "2021-02-10T085735Z"
 }
 """)))
@@ -50,7 +50,7 @@ class UpdateResultTest(unittest.TestCase):
     def test_reads_default_values_for_empty_dict(self):
         self.assertEqual(
             update.result.Result(
-                error='',
+                error=None,
                 timestamp=datetime.datetime.utcfromtimestamp(0),
             ), update.result.read(io.StringIO('{}')))
 
@@ -58,7 +58,7 @@ class UpdateResultTest(unittest.TestCase):
         mock_file = io.StringIO()
         update.result.write(
             update.result.Result(
-                error='',
+                error=None,
                 timestamp=datetime.datetime(2021,
                                             2,
                                             10,
@@ -67,7 +67,7 @@ class UpdateResultTest(unittest.TestCase):
                                             35,
                                             tzinfo=datetime.timezone.utc),
             ), mock_file)
-        self.assertEqual(('{"error": "", "timestamp": "2021-02-10T085735Z"}'),
+        self.assertEqual(('{"error": null, "timestamp": "2021-02-10T085735Z"}'),
                          mock_file.getvalue())
 
     def test_writes_error_result_accurately(self):

--- a/app/update/status.py
+++ b/app/update/status.py
@@ -23,7 +23,7 @@ def get():
     Returns:
         A two-tuple where the first value is a Status enum and the second is a
         string containing the error associated with a recently completed update
-        job. If the job completed successfully, the error string is empty.
+        job. If the job completed successfully, the second value is None.
     """
     if _is_update_process_running():
         return Status.IN_PROGRESS, None


### PR DESCRIPTION
The previous implementation was inconsistent about what value the update status API returned for the error field. Through some code paths, it would return an empty string for the error field on success, and for other code paths, it returned null.

This changes the update modules so that they consistently use an error value of None/null to represent a successful update result.