### PR TITLE
Change update result reader to update result store

### DIFF
--- a/app/update/status.py
+++ b/app/update/status.py
@@ -2,7 +2,7 @@ import enum
 import subprocess
 
 import update.launcher
-import update.result_reader
+import update.result_store
 
 
 class Status(enum.Enum):
@@ -28,7 +28,7 @@ def get():
     if _is_update_process_running():
         return Status.IN_PROGRESS, None
 
-    recent_result = update.result_reader.read()
+    recent_result = update.result_store.read()
     if not recent_result:
         return Status.NOT_RUNNING, None
 

--- a/app/update/status_test.py
+++ b/app/update/status_test.py
@@ -8,7 +8,7 @@ import update.status
 class StatusTest(unittest.TestCase):
 
     @mock.patch.object(update.status.subprocess, 'check_output')
-    @mock.patch.object(update.status.update.result_reader, 'read')
+    @mock.patch.object(update.status.update.result_store, 'read')
     def test_returns_not_running_when_there_is_no_process_nor_result_file(
             self, mock_read_update_result, mock_check_output):
         mock_check_output.return_value = """
@@ -23,7 +23,7 @@ root        51  0.0  0.0 103152 21264 ?        Ss   Apr03   0:00 /lib/dummy-b
         self.assertIsNone(error_actual)
 
     @mock.patch.object(update.status.subprocess, 'check_output')
-    @mock.patch.object(update.status.update.result_reader, 'read')
+    @mock.patch.object(update.status.update.result_store, 'read')
     def test_returns_in_progress_when_update_process_is_running(
             self, mock_read_update_result, mock_check_output):
         mock_check_output.return_value = """
@@ -38,7 +38,7 @@ root        51  0.0  0.0 103152 21264 ?        Ss   Apr03   0:00 /opt/tinypilot-
         self.assertIsNone(error_actual)
 
     @mock.patch.object(update.status.subprocess, 'check_output')
-    @mock.patch.object(update.status.update.result_reader, 'read')
+    @mock.patch.object(update.status.update.result_store, 'read')
     def test_ignores_update_result_if_update_is_running(self,
                                                         mock_read_update_result,
                                                         mock_check_output):
@@ -58,7 +58,7 @@ root        51  0.0  0.0 103152 21264 ?        Ss   Apr03   0:00 /opt/tinypilot-
         self.assertIsNone(error_actual)
 
     @mock.patch.object(update.status.subprocess, 'check_output')
-    @mock.patch.object(update.status.update.result_reader, 'read')
+    @mock.patch.object(update.status.update.result_store, 'read')
     def test_returns_success_when_no_process_is_running_and_last_run_was_ok(
             self, mock_read_update_result, mock_check_output):
         mock_check_output.return_value = """
@@ -74,7 +74,7 @@ root        51  0.0  0.0 103152 21264 ?        Ss   Apr03   0:00 /lib/dummy-b
         self.assertIsNone(error_actual)
 
     @mock.patch.object(update.status.subprocess, 'check_output')
-    @mock.patch.object(update.status.update.result_reader, 'read')
+    @mock.patch.object(update.status.update.result_store, 'read')
     def test_returns_error_when_no_process_is_running_and_last_run_had_error(
             self, mock_read_update_result, mock_check_output):
         mock_check_output.return_value = """

--- a/scripts/update-service
+++ b/scripts/update-service
@@ -11,12 +11,11 @@
 import argparse
 import datetime
 import logging
-import os
 import subprocess
 
 import update.launcher
 import update.result
-import update.result_reader
+import update.result_store
 import utc
 
 logger = logging.getLogger(__name__)
@@ -37,7 +36,7 @@ def configure_logging():
 
 def perform_update():
     result = run_update_script()
-    write_result(result)
+    update.result_store.write(result)
 
 
 def run_update_script():
@@ -62,14 +61,6 @@ def run_update_script():
     result.error = ''
     result.timestamp = utc.now()
     return result
-
-
-def write_result(result):
-    result_path = update.result_reader.result_path(result.timestamp)
-    os.makedirs(os.path.dirname(result_path), exist_ok=True)
-    with open(result_path, 'w') as result_file:
-        logger.info('Writing result file to %s', result_path)
-        update.result.write(result, result_file)
 
 
 def main(_):


### PR DESCRIPTION
It makes more sense for this module to handle both reading and writing persistent data about updates, and it makes it easier to test the logic.