### PR TITLE
Clear previous update results before launching new update

### DIFF
--- a/app/update/launcher.py
+++ b/app/update/launcher.py
@@ -1,6 +1,7 @@
 import logging
 import subprocess
 
+import update.result_store
 import update.status
 
 logger = logging.getLogger(__name__)
@@ -29,6 +30,8 @@ def start_async():
     current_state, _ = update.status.get()
     if current_state == update.status.Status.IN_PROGRESS:
         raise AlreadyInProgressError('An update is already in progress')
+
+    update.result_store.clear()
 
     subprocess.Popen(
         ('sudo', '/usr/sbin/service', 'tinypilot-updater', 'start'))

--- a/app/update/launcher_test.py
+++ b/app/update/launcher_test.py
@@ -12,46 +12,54 @@ from update import launcher
 class LauncherTest(unittest.TestCase):
 
     @mock.patch.object(launcher.subprocess, 'Popen')
+    @mock.patch.object(launcher.update.result_store, 'clear')
     @mock.patch.object(launcher.update.status, 'get')
     def test_launches_update_when_no_update_is_running(self, mock_status_get,
-                                                       mock_popen):
+                                                       mock_clear, mock_popen):
         mock_status_get.return_value = (update_status.Status.NOT_RUNNING, '')
 
         launcher.start_async()
 
+        mock_clear.assert_called()
         mock_popen.assert_called_once_with(
             ('sudo', '/usr/sbin/service', 'tinypilot-updater', 'start'))
 
     @mock.patch.object(launcher.subprocess, 'Popen')
+    @mock.patch.object(launcher.update.result_store, 'clear')
     @mock.patch.object(launcher.update.status, 'get')
     def test_launches_update_when_previous_update_succeeded(
-            self, mock_status_get, mock_popen):
+            self, mock_status_get, mock_clear, mock_popen):
         mock_status_get.return_value = (update_status.Status.DONE, '')
 
         launcher.start_async()
 
+        mock_clear.assert_called()
         mock_popen.assert_called_once_with(
             ('sudo', '/usr/sbin/service', 'tinypilot-updater', 'start'))
 
     @mock.patch.object(launcher.subprocess, 'Popen')
+    @mock.patch.object(launcher.update.result_store, 'clear')
     @mock.patch.object(launcher.update.status, 'get')
     def test_launches_update_when_previous_update_failed(
-            self, mock_status_get, mock_popen):
+            self, mock_status_get, mock_clear, mock_popen):
         mock_status_get.return_value = (update_status.Status.DONE,
                                         'dummy updater failure message')
 
         launcher.start_async()
 
+        mock_clear.assert_called_once()
         mock_popen.assert_called_once_with(
             ('sudo', '/usr/sbin/service', 'tinypilot-updater', 'start'))
 
     @mock.patch.object(launcher.subprocess, 'Popen')
+    @mock.patch.object(launcher.update.result_store, 'clear')
     @mock.patch.object(launcher.update.status, 'get')
     def test_does_not_launch_if_update_is_already_running(
-            self, mock_status_get, mock_popen):
+            self, mock_status_get, mock_clear, mock_popen):
         mock_status_get.return_value = (update_status.Status.IN_PROGRESS, '')
 
         with self.assertRaises(launcher.AlreadyInProgressError):
             launcher.start_async()
 
+        mock_clear.assert_not_called()
         mock_popen.assert_not_called()

--- a/app/update/result.py
+++ b/app/update/result.py
@@ -11,6 +11,9 @@ class Result:
     # succeeded.
     error: str
     # Time at which the update completed.
+    # Deprecated as of 1.4.2. We write this field but no longer read it. We're
+    # keeping it around in case we failed to anticipate something in the update
+    # logic and we end up needing it, but we can likely remove it after 1.4.2.
     timestamp: datetime.datetime
 
 

--- a/app/update/result_store.py
+++ b/app/update/result_store.py
@@ -43,8 +43,8 @@ def read():
         None.
 
     Returns:
-        An update.result.Result based on the most recent update result file
-        within the time threshold or None if none exist.
+        An update.result.Result based on the most recent update result file or
+        None if no update results exist.
     """
     try:
         with open(_RESULT_PATH) as result_file:

--- a/app/update/result_store.py
+++ b/app/update/result_store.py
@@ -32,14 +32,16 @@ _RESULT_PATH = os.path.join(_RESULT_FILE_DIR, 'latest-update-result.json')
 
 # Prior to 1.4.2, each update created its own separate result file, prefixed
 # with a UTC timestamp in ISO-8601. This glob pattern matches both the
-# legacy-style file naming and the new style naming.
+# legacy-style file naming and the new-style naming.
 _RESULT_GLOB_PATTERN = os.path.join(_RESULT_FILE_DIR, '*-update-result.json')
 
 
 def read():
     """Reads the most recent update result.
+
     Args:
         None.
+
     Returns:
         An update.result.Result based on the most recent update result file
         within the time threshold or None if none exist.
@@ -66,12 +68,14 @@ def _read_legacy():
 
 
 def clear():
+    """Clears the result store of all previous update results."""
     result_files = glob.glob(_RESULT_GLOB_PATTERN)
     for result_file in result_files:
         os.remove(result_file)
 
 
 def write(result):
+    """Writes an update result to the result store."""
     os.makedirs(_RESULT_FILE_DIR, exist_ok=True)
     with open(_RESULT_PATH, 'w') as result_file:
         print('Writing result file to %s' % _RESULT_PATH)

--- a/app/update/result_store.py
+++ b/app/update/result_store.py
@@ -76,8 +76,7 @@ def clear():
 
 def write(result):
     """Writes an update result to the result store."""
+    logger.info('Writing result file to %s', _RESULT_PATH)
     os.makedirs(_RESULT_FILE_DIR, exist_ok=True)
     with open(_RESULT_PATH, 'w') as result_file:
-        print('Writing result file to %s' % _RESULT_PATH)
-        logger.info('Writing result file to %s', _RESULT_PATH)
         update.result.write(result, result_file)

--- a/app/update/result_store.py
+++ b/app/update/result_store.py
@@ -1,8 +1,11 @@
 """Manages persistent data about the result of the most recent TinyPilot update.
+
 The update result store stores and fetches the result of the last update.
 Because the TinyPilot server holds no state in memory, it relies on files stored
 in the ~/logs directory to record the result of the most recent update.
+
 The flow of an update is as follows:
+
 1. User initiates an update.
 2. Server clears result files of all previous updates.
 3. Server initiates the update process.
@@ -45,7 +48,8 @@ def read():
         with open(_RESULT_PATH) as result_file:
             return update.result.read(result_file)
     except FileNotFoundError:
-        # If the 1.4.2
+        # If we can't find a result file with >=1.4.2 style naming, check for
+        # legacy result files.
         return _read_legacy()
 
 

--- a/app/update/result_store.py
+++ b/app/update/result_store.py
@@ -1,83 +1,56 @@
 """Manages persistent data about the result of the most recent TinyPilot update.
-
-The update result store saves and fetches the result of the last update. Because
-the TinyPilot server holds no state in memory, it relies on files stored in the
-~/logs directory to record the result of the most recent update.
-
-The happy path of the update is as follows:
-1. User initiates an update
-2. User queries for update status and the server reports an update is in
-   progress because it can see the update process running.
-3. User repeats (2) for a few minutes until the update completes.
-4. At the end of the update, the update process writes an update result file.
-5. The next time the user queries for update status, the server reads the
-   update result file and reports the result of the update based on the file
+The update result store stores and fetches the result of the last update.
+Because the TinyPilot server holds no state in memory, it relies on files stored
+in the ~/logs directory to record the result of the most recent update.
+The flow of an update is as follows:
+1. User initiates an update.
+2. Server clears result files of all previous updates.
+3. Server initiates the update process.
+4. User queries for update status and the server reports an update is in
+    progress because it can see the update process running.
+5. User repeats (4) for a few minutes until the update completes.
+6. At the end of the update, the update process writes an update result file.
+7. The next time the user queries for update status, the server reads the
+   update result file and reports the result of the update based on the file's
    contents.
-
-There are two interesting edge cases we have to handle:
-
-1. The user has initiated an update, but the update process is not yet running.
-     TinyPilot will check for a result file, and it may see results from
-     previous updates, so we have to recognize them as stale and not the result
-     of the update the user just initiated.
-2. The update process crashed without ever writing a result file.
-     This should be rare, but similarly to (1), we have to make sure we don't
-     confuse the result of a previous update with the result of an update that
-     never wrote a result file because it crashed.
-
-The update result reader handles these edge cases by reading the timestamp of
-the update result. For TinyPilot versions < 1.4.1, the timestamp represents the
-start of the update process. For TinyPilot version >= 1.4.1, the timestamp
-represents the end of the update process.
-
-The result reader has a threshold, before which it assumes result files are from
-previous update runs (_RECENT_UPDATE_THRESHOLD_SECONDS). The threshold is
-currently set to eight 8 minutes. That means that the update reader will ignore
-any result files that are timestamped more than 8 minutes prior to the current
-time.
-
-This solution is brittle because the 8 minutes is arbitrary, and there are still
-situations where a previous update might be misinterpreted as the current result
-(e.g., two updates in a row, within 8 minutes).
-
-https://github.com/mtlynch/tinypilot/issues/597 tracks the work to replace the
-update logic with a better solution.
 """
 
 import glob
 import logging
 import os
 
-import iso8601
 import update.result
-import utc
 
 logger = logging.getLogger(__name__)
 
 _RESULT_FILE_DIR = os.path.expanduser('~/logs')
 
-# Cutoff under which an update is considered "recently" completed. It should be
-# just long enough that it's the one we see right after a device reboot but not
-# so long that there's risk of it being confused with the result from a later
-# update attempt.
-_RECENT_UPDATE_THRESHOLD_SECONDS = 60 * 8
+_RESULT_PATH = os.path.join(_RESULT_FILE_DIR, 'latest-update-result.json')
 
-# Result files are prefixed with UTC timestamps in ISO-8601 format.
-_UPDATE_RESULT_FILENAME_FORMAT = '%s-update-result.json'
+# Prior to 1.4.2, each update created its own separate result file, prefixed
+# with a UTC timestamp in ISO-8601. This glob pattern matches both the
+# legacy-style file naming and the new style naming.
+_RESULT_GLOB_PATTERN = os.path.join(_RESULT_FILE_DIR, '*-update-result.json')
 
 
 def read():
-    """Reads the most recent update result, filtering results that are too old.
-
+    """Reads the most recent update result.
     Args:
         None.
-
     Returns:
         An update.result.Result based on the most recent update result file
         within the time threshold or None if none exist.
     """
-    result_files = glob.glob(
-        os.path.join(_RESULT_FILE_DIR, _UPDATE_RESULT_FILENAME_FORMAT % '*'))
+    try:
+        with open(_RESULT_PATH) as result_file:
+            return update.result.read(result_file)
+    except FileNotFoundError:
+        # If the 1.4.2
+        return _read_legacy()
+
+
+def _read_legacy():
+    result_files = glob.glob(_RESULT_GLOB_PATTERN)
     if not result_files:
         return None
 
@@ -85,21 +58,18 @@ def read():
     # most recently created file.
     most_recent_result_file = sorted(result_files)[-1]
     with open(most_recent_result_file) as result_file:
-        most_recent_result = update.result.read(result_file)
+        return update.result.read(result_file)
 
-    # Ignore the result if it's too old.
-    delta = utc.now() - most_recent_result.timestamp
-    if delta.total_seconds() > _RECENT_UPDATE_THRESHOLD_SECONDS:
-        return None
 
-    return most_recent_result
+def clear():
+    result_files = glob.glob(_RESULT_GLOB_PATTERN)
+    for result_file in result_files:
+        os.remove(result_file)
 
 
 def write(result):
-    result_path = os.path.join(
-        _RESULT_FILE_DIR,
-        _UPDATE_RESULT_FILENAME_FORMAT % iso8601.to_string(result.timestamp))
     os.makedirs(_RESULT_FILE_DIR, exist_ok=True)
-    with open(result_path, 'w') as result_file:
-        logger.info('Writing result file to %s', result_path)
+    with open(_RESULT_PATH, 'w') as result_file:
+        print('Writing result file to %s' % _RESULT_PATH)
+        logger.info('Writing result file to %s', _RESULT_PATH)
         update.result.write(result, result_file)

--- a/app/update/result_store.py
+++ b/app/update/result_store.py
@@ -60,8 +60,8 @@ def _read_legacy():
     if not result_files:
         return None
 
-    # Filenames start with a timestamp, so the last one lexicographically is the
-    # most recently created file.
+    # Legacy filenames start with a ISO-8601 timestamp, so the last one
+    # lexicographically is the most recently created file.
     most_recent_result_file = sorted(result_files)[-1]
     with open(most_recent_result_file) as result_file:
         return update.result.read(result_file)

--- a/app/update/result_store_test.py
+++ b/app/update/result_store_test.py
@@ -168,8 +168,8 @@ class ResultStoreClearTest(unittest.TestCase):
     # pylint: disable=no-self-use
     @mock.patch.object(update.result_store.os, 'remove')
     @mock.patch.object(update.result_store.glob, 'glob')
-    def test_clear_does_nothing_when_no_result_files_exist(
-            self, mock_glob, mock_remove):
+    def test_does_nothing_when_no_result_files_exist(self, mock_glob,
+                                                     mock_remove):
         mock_glob.return_value = []
 
         update.result_store.clear()


### PR DESCRIPTION
One of the most complicated aspects of the in-browser updates is recording state on the update despite the fact that the Flask server is stateless.

TinyPilot currently achieves this by writing an "update result file" at the end of each update. But there's complexity there because the server has to make sure that when the user requests status of an update, the server isn't checking an obsolete update file (e.g., the recently launched update hasn't written a file yet, so the only update result is from an update two weeks ago).

Currently, we solved this with timestamps, where we defined a time threshold of eight minutes. So, if the server found a result from more than eight minutes ago, it would assume it was irrelevant to the user's current request about update job status. That's a brittle solution, and it failed in 1.4.1 because the threshold was too low.

This change gets rid of the time threshold and instead clears previous update result files when a new update is starting. This ensures that there can only be zero or one update results on the system at any given time, so there's no need to check for timestamps. It's not possible for stale result files to be lying around because they would have been cleared before the latest update launched.

The first time the user updates TinyPilot from a version below this PR to a version that includes it, their system will still have multiple update result files. We're preserving logic for reading legacy files if TinyPilot can't find a result under the new result file naming scheme.

Fixes #597

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mtlynch/tinypilot/662)
<!-- Reviewable:end -->
