### PR TITLE
Fix result logic in update-service

### DIFF
--- a/scripts/update-service
+++ b/scripts/update-service
@@ -9,7 +9,6 @@
 # pylint:disable=invalid-name
 
 import argparse
-import datetime
 import logging
 import subprocess
 
@@ -40,27 +39,26 @@ def perform_update():
 
 
 def run_update_script():
-    result = update.result.Result(
-        error='The update did not complete',
-        timestamp=datetime.datetime.utcfromtimestamp(0))
+    logger.info('Launching update script: %s',
+                update.launcher.UPDATE_SCRIPT_PATH)
     try:
-        logger.info('Launching update script: %s',
-                    update.launcher.UPDATE_SCRIPT_PATH)
         subprocess.run(['sudo', update.launcher.UPDATE_SCRIPT_PATH],
                        check=True,
                        timeout=_UPDATE_TIMEOUT_SECONDS)
-        logger.info('Update completed successfully')
     except subprocess.TimeoutExpired:
         logger.error('Update process timed out')
-        result.error = 'The update timed out'
+        return make_update_result(update_error='The update timed out')
     except subprocess.CalledProcessError as e:
         logger.error('Update process terminated with failing exit code: %s',
                      str(e))
-        result.error = 'The update failed: %s' % str(e)
+        return make_update_result(update_error='The update failed: %s' % str(e))
 
-    result.error = ''
-    result.timestamp = utc.now()
-    return result
+    logger.info('Update completed successfully')
+    return make_update_result(update_error=None)
+
+
+def make_update_result(update_error):
+    return update.result.Result(error=update_error, timestamp=utc.now())
 
 
 def main(_):


### PR DESCRIPTION
There was a bug in the error recording logic of update-service. Previously, if an error occurred during the try/catch, it was recorded in the update result's error field, but then the last line of the function overwrote any error with an empty string, erasing the record of the error.

This rewrites the logic so that each exit path generates its own update result object, so it's harder for values from one result to bleed into another code path.

This also changes the semantics of the success case so that error=None instead of error=''. In #659, we updated all instances of the error field to use error=None to represent success, but we missed the usage in update-service.

Fixes #665