### PR TITLE
Change uStreamer jpeg quality from the web UI

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -7,6 +7,7 @@ import local_system
 import request_parsers.errors
 import request_parsers.hostname
 import request_parsers.video_fps
+import request_parsers.video_jpeg_quality
 import update.launcher
 import update.settings
 import update.status
@@ -312,6 +313,85 @@ def settings_video_fps_put():
             settings.ustreamer_desired_fps = video_fps
         update.settings.save(settings)
     except (request_parsers.errors.InvalidVideoFpsError,
+            update.settings.SaveSettingsError) as e:
+        return json_response.error(str(e)), 200
+    return json_response.success()
+
+
+@api_blueprint.route('/settings/video/jpeg_quality', methods=['GET'])
+def settings_video_jpeg_quality_get():
+    """Retrieves the current video JPEG quality setting.
+
+    Returns:
+        A JSON string with three keys when successful and two otherwise:
+        success, error and videoJpegQuality (if successful).
+
+        success: true if successful.
+        error: null if successful, str otherwise.
+        videoJpegQuality: int.
+
+        Example of success:
+        {
+            'success': true,
+            'error': null,
+            'videoJpegQuality': 80
+        }
+        Example of error:
+        {
+            'success': false,
+            'error': 'Failed to load settings from settings file'
+        }
+    """
+    try:
+        video_jpeg_quality = update.settings.load().ustreamer_quality
+        # Note: Default values are not set in the settings file. So when the
+        # values are unset, we must respond with the correct default value.
+        if video_jpeg_quality is None:
+            video_jpeg_quality = video_settings.DEFAULT_JPEG_QUALITY
+    except update.settings.LoadSettingsError as e:
+        return json_response.error(str(e)), 200
+    return json_response.success({'videoJpegQuality': video_jpeg_quality})
+
+
+@api_blueprint.route('/settings/video/jpeg_quality', methods=['PUT'])
+def settings_video_jpeg_quality_put():
+    """Changes the current video JPEG quality setting.
+
+    Expects a JSON data structure in the request body that contains the
+    new videoJpegQuality as an integer. Example:
+    {
+        'videoJpegQuality': 80
+    }
+
+    Returns:
+        A JSON string with two keys: success, error.
+
+        success: true if successful.
+        error: null if successful, str otherwise.
+
+        Example of success:
+        {
+            'success': true,
+            'error': null
+        }
+        Example of error:
+        {
+            'success': false,
+            'error': 'Failed to save settings to settings file'
+        }
+    """
+    try:
+        video_jpeg_quality = request_parsers.video_jpeg_quality.parse(
+            flask.request)
+        settings = update.settings.load()
+        # Note: To avoid polluting the settings file with unnecessay default
+        # values, we unset them instead.
+        if video_jpeg_quality == video_settings.DEFAULT_JPEG_QUALITY:
+            del settings.ustreamer_quality
+        else:
+            settings.ustreamer_quality = video_jpeg_quality
+        update.settings.save(settings)
+    except (request_parsers.errors.InvalidVideoJpegQualityError,
             update.settings.SaveSettingsError) as e:
         return json_response.error(str(e)), 200
     return json_response.success()

--- a/app/api.py
+++ b/app/api.py
@@ -266,12 +266,12 @@ def settings_video_fps_get():
     """
     try:
         video_fps = update.settings.load().ustreamer_desired_fps
-        # Note: Default values are not set in the settings file. So when the
-        # values are unset, we must respond with the correct default value.
-        if video_fps is None:
-            video_fps = video_settings.DEFAULT_FPS
     except update.settings.LoadSettingsError as e:
         return json_response.error(str(e)), 200
+    # Note: Default values are not set in the settings file. So when the
+    # values are unset, we must respond with the correct default value.
+    if video_fps is None:
+        video_fps = video_settings.DEFAULT_FPS
     return json_response.success({'videoFps': video_fps})
 
 
@@ -344,12 +344,12 @@ def settings_video_jpeg_quality_get():
     """
     try:
         video_jpeg_quality = update.settings.load().ustreamer_quality
-        # Note: Default values are not set in the settings file. So when the
-        # values are unset, we must respond with the correct default value.
-        if video_jpeg_quality is None:
-            video_jpeg_quality = video_settings.DEFAULT_JPEG_QUALITY
     except update.settings.LoadSettingsError as e:
         return json_response.error(str(e)), 200
+    # Note: Default values are not set in the settings file. So when the
+    # values are unset, we must respond with the correct default value.
+    if video_jpeg_quality is None:
+        video_jpeg_quality = video_settings.DEFAULT_JPEG_QUALITY
     return json_response.success({'videoJpegQuality': video_jpeg_quality})
 
 

--- a/app/request_parsers/errors.py
+++ b/app/request_parsers/errors.py
@@ -16,3 +16,7 @@ class InvalidHostnameError(Error):
 
 class InvalidVideoFpsError(Error):
     pass
+
+
+class InvalidVideoJpegQualityError(Error):
+    pass

--- a/app/request_parsers/validators/video_jpeg_quality.py
+++ b/app/request_parsers/validators/video_jpeg_quality.py
@@ -1,0 +1,2 @@
+def validate(value):
+    return 1 <= value <= 100

--- a/app/request_parsers/validators/video_jpeg_quality_test.py
+++ b/app/request_parsers/validators/video_jpeg_quality_test.py
@@ -1,0 +1,15 @@
+import unittest
+
+from request_parsers.validators import video_jpeg_quality
+
+
+class VideoJpegQualityValidationTest(unittest.TestCase):
+
+    def test_reject_integers_out_of_bounds(self):
+        self.assertFalse(video_jpeg_quality.validate(0))
+        self.assertFalse(video_jpeg_quality.validate(101))
+
+    def test_accept_integers_within_bounds(self):
+        self.assertTrue(video_jpeg_quality.validate(1))
+        self.assertTrue(video_jpeg_quality.validate(50))
+        self.assertTrue(video_jpeg_quality.validate(100))

--- a/app/request_parsers/video_jpeg_quality.py
+++ b/app/request_parsers/video_jpeg_quality.py
@@ -1,0 +1,22 @@
+from request_parsers import errors
+from request_parsers import message as message_parser
+from request_parsers.validators import \
+    video_jpeg_quality as video_jpeg_quality_validator
+
+
+def parse(request):
+    message = message_parser.parse_message(request,
+                                           required_fields=['videoJpegQuality'])
+    try:
+        # Note: We need to cast the value to a string first otherwise the int
+        # function forces floats into integers by simply cutting off the
+        # fractional part. This results in the value being incorrectly
+        # validated as an integer.
+        video_jpeg_quality = int(str(message['videoJpegQuality']))
+        if not video_jpeg_quality_validator.validate(video_jpeg_quality):
+            raise ValueError
+    except ValueError as e:
+        raise errors.InvalidVideoJpegQualityError(
+            'The video JPEG quality must be an whole number between 1 and 100.'
+        ) from e
+    return video_jpeg_quality

--- a/app/request_parsers/video_jpeg_quality_test.py
+++ b/app/request_parsers/video_jpeg_quality_test.py
@@ -1,0 +1,48 @@
+import unittest
+from unittest import mock
+
+from request_parsers import errors
+from request_parsers import video_jpeg_quality
+
+
+def make_mock_request(json_data):
+    mock_request = mock.Mock()
+    mock_request.get_json.return_value = json_data
+    return mock_request
+
+
+class VideoJpegQualityParserTest(unittest.TestCase):
+
+    def test_reject_integers_out_of_bounds(self):
+        with self.assertRaises(errors.InvalidVideoJpegQualityError):
+            video_jpeg_quality.parse(make_mock_request({'videoJpegQuality': 0}))
+        with self.assertRaises(errors.InvalidVideoJpegQualityError):
+            video_jpeg_quality.parse(
+                make_mock_request({'videoJpegQuality': 101}))
+
+    def test_accept_integers_within_bounds(self):
+        self.assertEqual(
+            1,
+            video_jpeg_quality.parse(make_mock_request({'videoJpegQuality': 1
+                                                       })))
+        self.assertEqual(
+            50,
+            video_jpeg_quality.parse(make_mock_request({'videoJpegQuality': 50
+                                                       })))
+        self.assertEqual(
+            100,
+            video_jpeg_quality.parse(
+                make_mock_request({'videoJpegQuality': 100})))
+
+    def test_reject_non_integers(self):
+        for value in [
+                None, True, '', ' ', 'yes', '$', '3.0', '.1', 15.0, (), [], {}
+        ]:
+            with self.subTest(value):
+                with self.assertRaises(errors.InvalidVideoJpegQualityError):
+                    video_jpeg_quality.parse(
+                        make_mock_request({'videoJpegQuality': value}))
+
+    def test_reject_incorrect_key(self):
+        with self.assertRaises(errors.MissingFieldError):
+            video_jpeg_quality.parse(make_mock_request({'jpegQuality': 1}))

--- a/app/static/js/controllers.js
+++ b/app/static/js/controllers.js
@@ -357,6 +357,42 @@
       .then(() => {});
   }
 
+  function getVideoJpegQuality() {
+    return fetch("/api/settings/video/jpeg_quality", {
+      method: "GET",
+      mode: "same-origin",
+      cache: "no-cache",
+      redirect: "error",
+    })
+      .then(readHttpJsonResponse)
+      .then(checkJsonSuccess)
+      .then((data) => {
+        if (!data.hasOwnProperty("videoJpegQuality")) {
+          return Promise.reject(
+            new Error("Missing expected videoJpegQuality field")
+          );
+        }
+        return Promise.resolve(data.videoJpegQuality);
+      });
+  }
+
+  function setVideoJpegQuality(videoJpegQuality) {
+    return fetch("/api/settings/video/jpeg_quality", {
+      method: "PUT",
+      mode: "same-origin",
+      cache: "no-cache",
+      redirect: "error",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRFToken": getCsrfToken(),
+      },
+      body: JSON.stringify({ videoJpegQuality }),
+    })
+      .then(readHttpJsonResponse)
+      .then(checkJsonSuccess)
+      .then(() => {});
+  }
+
   function applyVideoSettings() {
     return fetch("/api/settings/video/apply", {
       method: "POST",
@@ -388,5 +424,7 @@
   window.controllers.textToShareableUrl = textToShareableUrl;
   window.controllers.getVideoFps = getVideoFps;
   window.controllers.setVideoFps = setVideoFps;
+  window.controllers.getVideoJpegQuality = getVideoJpegQuality;
+  window.controllers.setVideoJpegQuality = setVideoJpegQuality;
   window.controllers.applyVideoSettings = applyVideoSettings;
 })(window);

--- a/app/templates/custom-elements/video-settings-dialog.html
+++ b/app/templates/custom-elements/video-settings-dialog.html
@@ -18,12 +18,14 @@
     .input-container label {
       display: inline-block;
       text-align: right;
+      width: 100px;
     }
     .input-container input {
       display: inline-block;
     }
 
-    #video-fps-display {
+    #video-fps-display,
+    #video-jpeg-quality-display {
       display: inline-block;
       width: 50px;
     }
@@ -38,6 +40,11 @@
       <label for="video-fps">FPS:</label>
       <input type="range" id="video-fps" min="1" max="30" />
       <span id="video-fps-display"></span>
+    </div>
+    <div class="input-container">
+      <label for="video-jpeg-quality">JPEG Quality:</label>
+      <input type="range" id="video-jpeg-quality" min="1" max="100" />
+      <span id="video-jpeg-quality-display"></span>
     </div>
     <button class="save-btn btn-success" type="button">
       Apply
@@ -78,6 +85,11 @@
             .addEventListener("input", (event) => {
               this._setVideoFpsDisplay(event.target.value);
             });
+          this.shadowRoot
+            .querySelector("#video-jpeg-quality")
+            .addEventListener("input", (event) => {
+              this._setVideoJpegQualityDisplay(event.target.value);
+            });
         }
 
         get state() {
@@ -93,6 +105,13 @@
             "#video-fps-display"
           );
           videoFpsDisplayElement.innerHTML = videoFps;
+        }
+
+        _setVideoJpegQualityDisplay(videoJpegQuality) {
+          const videoJpegQualityDisplayElement = this.shadowRoot.querySelector(
+            "#video-jpeg-quality-display"
+          );
+          videoJpegQualityDisplayElement.innerHTML = videoJpegQuality;
         }
 
         _getVideoFps() {
@@ -111,9 +130,27 @@
             });
         }
 
+        _getVideoJpegQuality() {
+          return controllers
+            .getVideoJpegQuality()
+            .then((videoJpegQuality) => {
+              this.shadowRoot.querySelector(
+                "#video-jpeg-quality"
+              ).value = videoJpegQuality;
+              this._setVideoJpegQualityDisplay(videoJpegQuality);
+            })
+            .catch((error) => {
+              this._displayErrorDialog({
+                title: "Failed to Load Video JPEG Quality",
+                details: error,
+              });
+              return Promise.reject(error);
+            });
+        }
+
         getSettings() {
           this.state = "loading";
-          Promise.all([this._getVideoFps()])
+          Promise.all([this._getVideoFps(), this._getVideoJpegQuality()])
             .then(() => {
               this.state = "edit";
             })
@@ -134,9 +171,24 @@
           });
         }
 
+        _saveVideoJpegQuality() {
+          let videoJpegQuality = this.shadowRoot.querySelector(
+            "#video-jpeg-quality"
+          ).value;
+          return controllers
+            .setVideoJpegQuality(videoJpegQuality)
+            .catch((error) => {
+              this._displayErrorDialog({
+                title: "Failed to Save Video JPEG Quality",
+                details: error,
+              });
+              return Promise.reject(error);
+            });
+        }
+
         _saveSettings() {
           this.state = "saving";
-          Promise.all([this._saveVideoFps()])
+          Promise.all([this._saveVideoFps(), this._saveVideoJpegQuality()])
             .then(controllers.applyVideoSettings)
             .then(() => {
               // Note: After the video stream stops, it doesn't try to

--- a/app/update/settings.py
+++ b/app/update/settings.py
@@ -71,6 +71,19 @@ class Settings:
         if 'ustreamer_desired_fps' in self._data:
             del self._data['ustreamer_desired_fps']
 
+    @property
+    def ustreamer_quality(self):
+        return self._data.get('ustreamer_quality', None)
+
+    @ustreamer_quality.setter
+    def ustreamer_quality(self, value):
+        self._data['ustreamer_quality'] = value
+
+    @ustreamer_quality.deleter
+    def ustreamer_quality(self):
+        if 'ustreamer_quality' in self._data:
+            del self._data['ustreamer_quality']
+
 
 def load():
     """Retrieves the current TinyPilot update settings

--- a/app/video_settings.py
+++ b/app/video_settings.py
@@ -3,6 +3,7 @@ import subprocess
 
 _UPDATE_SCRIPT_PATH = '/opt/tinypilot-privileged/update-video-settings'
 DEFAULT_FPS = 30
+DEFAULT_JPEG_QUALITY = 80
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
This PR adds "JPEG Quality" to the `video-settings-dialog` custom element. [Video demo](https://www.loom.com/share/8b5dc0a54c0746b19ee6ebcea11c4cf8).

This is a continuation of the work done in #629 of allowing video settings to be changed via the web UI.

This relies on https://github.com/mtlynch/ansible-role-ustreamer/pull/39 to be merged.

Fixes #448

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mtlynch/tinypilot/667)
<!-- Reviewable:end -->
