### PR TITLE
Make styling of progress spinner adjustable

### DIFF
--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -43,7 +43,9 @@
 
   <div id="initializing">
     <p>Retrieving current hostname</p>
-    <progress-spinner></progress-spinner>
+    <div>
+      <progress-spinner></progress-spinner>
+    </div>
     <button id="cancel-initialization" type="button">Cancel</button>
   </div>
 

--- a/app/templates/custom-elements/progress-spinner.html
+++ b/app/templates/custom-elements/progress-spinner.html
@@ -2,14 +2,23 @@
   <style>
     @import "css/style.css";
 
+    :host {
+      --size: 5rem;
+      --thickness: 10px;
+      display: inline-block;
+    }
+
     .spinner {
       margin: auto;
-      border: 10px solid var(--brand-metallic-bright);
-      border-top: 10px solid var(--brand-blue);
+      width: var(--size);
+      height: var(--size);
+      border-width: var(--thickness);
+      border-style: solid;
+      border-color: var(--brand-metallic-bright);
+      border-top-color: var(--brand-blue);
       border-radius: 50%;
-      width: 60px;
-      height: 60px;
       animation: spin 1.5s linear infinite;
+      box-sizing: border-box;
     }
 
     @keyframes spin {

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -194,6 +194,16 @@
             document.getElementById("error-overlay").show();
           });
       </script>
+
+      <h2 class="section">Progress indicator</h2>
+      <p>
+        The spinner is used to indicate that an operation is in progress. The
+        styling can be adjusted through CSS variables.
+      </p>
+      <progress-spinner></progress-spinner>
+      <progress-spinner
+        style="--size: 2rem; --thickness: 5px;"
+      ></progress-spinner>
     </main>
   </body>
 </html>


### PR DESCRIPTION
In order to reuse the progress spinner in different layout contexts we have to refactor the CSS a little bit.

In this case I think it’s too arbitrary to hard-code specific variants, e.g. `size="large"` that would result in a fixed width of `1.8rem` or the like. Instead, it’s best if the caller can adjust the styling according to the context. That can be done through CSS variables. The usage is demonstrated in the style guide.

In the hostname dialog I had to wrap the spinner into a div, because it’s `inline-block` now – otherwise it would be placed in one line with the button there.

I also cleaned up the CSS a little bit.