### PR TITLE
Make button styles reusable (`.btn` class)

### DIFF
--- a/app/static/css/button.css
+++ b/app/static/css/button.css
@@ -1,6 +1,7 @@
 @import "style.css";
 
-button {
+button,
+.btn {
   display: inline-block;
   border: none;
   padding: 1rem 2rem;
@@ -18,28 +19,32 @@ button {
 }
 
 button:hover,
-button:focus {
+.btn:hover,
+button:focus,
+.btn:focus {
   background-color: var(--brand-metallic-bright);
 }
 
-button:focus {
+button:focus,
+.btn:focus {
   outline: 1px solid #fff;
   outline-offset: -4px;
 }
 
-button:active {
+button:active,
+.btn:active {
   transform: scale(0.99);
 }
 
-button.btn-success {
+.btn-success {
   background-color: var(--brand-green);
 }
 
-button.btn-success:hover {
+.btn-success:hover {
   background-color: var(--brand-green-bright);
 }
 
-button.btn-success:disabled {
+.btn-success:disabled {
   background-color: var(--brand-green-light);
   cursor: not-allowed;
 }

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -117,7 +117,7 @@
         </li>
       </ul>
       <h3>Default Button</h3>
-      <button class="btn">Default</button>
+      <button>Default</button>
       <p>For harmless operations like “close” or “cancel”.</p>
       <h3>Danger Button</h3>
       <button class="btn-danger">Danger</button>


### PR DESCRIPTION
Currently the button styles are only available on a `<button>` element. In order to make other elements look like a button, we need to introduce a separate CSS class.

Just fyi about the `button.btn-success { ... }`: it is a bit of an antipattern in CSS to restrict a class to a certain element. There is not really a benefit in doing this and it makes reusing the class harder. It can also be a problem when composing CSS classes, because `element.classname` takes precedence over just `.classname` in the hierarchy, so it’s harder to override.

For whatever reason we had `<button class="btn">` in the style guide. The class didn’t exist before, though, and it’s superfluous anyway.