### PR TITLE
Use title case and proper headlines in overlays

### DIFF
--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -42,7 +42,7 @@
   </style>
 
   <div id="initializing">
-    <p>Retrieving current hostname</p>
+    <h3>Retrieving Current Hostname</h3>
     <div>
       <progress-spinner></progress-spinner>
     </div>
@@ -60,7 +60,7 @@
       <p id="input-error"><!-- Filled programmatically --></p>
     </div>
     <button id="change-and-restart" class="btn-success" type="button">
-      Change and restart
+      Change and Restart
     </button>
     <button id="cancel-hostname-change" type="button">Cancel</button>
   </div>

--- a/app/templates/custom-elements/debug-dialog.html
+++ b/app/templates/custom-elements/debug-dialog.html
@@ -52,7 +52,7 @@
 
   <!-- Get Debug Logs -->
   <div id="logs-loading">
-    <h3>Retrieving debug logs</h3>
+    <h3>Retrieving Debug Logs</h3>
     <progress-spinner></progress-spinner>
   </div>
 
@@ -60,10 +60,10 @@
     <h3>Debug Logs</h3>
     <p class="logs monospace"></p>
     <button class="share-btn btn-success" type="button">
-      Get shareable URL
+      Get Shareable URL
     </button>
     <button class="copy-btn btn-success" type="button">
-      Copy to clipboard
+      Copy to Clipboard
     </button>
     <button class="close-btn" type="button">Close</button>
   </div>


### PR DESCRIPTION
Quick boy scout refactoring, I stumbled across these two places and noticed they weren’t inline with the style guide.