### PR TITLE
Add --force to git fetch command

### DIFF
--- a/app/git.py
+++ b/app/git.py
@@ -50,7 +50,7 @@ def remote_head_commit_id():
 
 def _fetch():
     logger.info('Performing git fetch')
-    _run(['git', 'fetch'])
+    _run(['git', 'fetch', '--force'])
     logger.info('git fetch complete')
 
 


### PR DESCRIPTION
If the TinyPilot has any commits or tags that conflict with the server, the server's version should override the device's.

This has caused issues in cases where we accidentally published conflicting release tags, but then device that saw the old release tag error out if they see the new one.