### PR TITLE
Introduce new pattern for API responses (and migrate hostname feature)

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -177,9 +177,9 @@ def hostname_get():
         }
     """
     try:
-        return json_response.success({'hostname': hostname.determine()})
+        return json_response.success2({'hostname': hostname.determine()})
     except hostname.Error as e:
-        return json_response.error(str(e)), 200
+        return json_response.error2(e), 500
 
 
 @api_blueprint.route('/hostname', methods=['PUT'])

--- a/app/api.py
+++ b/app/api.py
@@ -200,9 +200,9 @@ def hostname_set():
         hostname.change(new_hostname)
         return json_response.success2()
     except request_parsers.errors.Error as e:
-        return json_response.error2('Invalid input', e), 400
+        return json_response.error2(e), 400
     except hostname.Error as e:
-        return json_response.error2('Operation failed', e), 500
+        return json_response.error2(e), 500
 
 
 @api_blueprint.route('/status', methods=['GET'])

--- a/app/api.py
+++ b/app/api.py
@@ -193,30 +193,16 @@ def hostname_set():
     }
 
     Returns:
-        A JSON string with two keys: success, error.
-
-        success: true if successful.
-        error: null if successful, str otherwise.
-
-        Example of success:
-        {
-            'success': true,
-            'error': null
-        }
-        Example of error:
-        {
-            'success': false,
-            'error': 'Invalid hostname.'
-        }
+        Empty response on success, error object otherwise.
     """
     try:
         new_hostname = request_parsers.hostname.parse_hostname(flask.request)
         hostname.change(new_hostname)
-        return json_response.success()
+        return json_response.success2()
     except request_parsers.errors.Error as e:
-        return json_response.error('Invalid input: %s' % str(e)), 200
+        return json_response.error2('Invalid input', e), 400
     except hostname.Error as e:
-        return json_response.error('Operation failed: %s' % str(e)), 200
+        return json_response.error2('Operation failed', e), 500
 
 
 @api_blueprint.route('/status', methods=['GET'])

--- a/app/json_response.py
+++ b/app/json_response.py
@@ -1,10 +1,13 @@
 import flask
 
+# We are currently migration from success/error to success2/error2.
+# The former will be eventually removed and the latter renamed.
+
 
 # The default dictionary is okay because we're not modifying it.
 # pylint: disable=dangerous-default-value
 def success(fields={}):
-    """A JSON response for a successful request.
+    """A JSON response for a successful request. (DEPRECATED, use `success2`)
 
     Args:
         fields: Dictionary with JSON properties to include.
@@ -24,7 +27,7 @@ def success(fields={}):
 
 
 def error(message):
-    """A JSON response for a failed request.
+    """A JSON response for a failed request. (DEPRECATED, use `error2`)
 
     Args:
         message: String containing the error message.
@@ -43,10 +46,30 @@ def error(message):
 # The default dictionary is okay because we're not modifying it.
 # pylint: disable=dangerous-default-value
 def success2(data={}):
+    """A JSON response for a successful request.
+
+    Args:
+        data: Dictionary with JSON properties to include.
+
+    Returns:
+        A `flask.Response` object with JSON body containing the serialized data.
+    """
     return flask.jsonify(data)
 
 
 def error2(original_error):
+    """A JSON response for a failed request.
+
+    Args:
+        original_error: The original error object
+
+    Returns:
+        A `flask.Response` object with JSON body. The JSON contains two fields:
+        - message: A string with the error message.
+        - code: Either a string with a unique error code as string, or `null`.
+            This property is only set for errors that are handled explicitly by
+            the TinyPilot frontend.
+    """
     code = original_error.code if hasattr(original_error, 'code') else None
     return flask.jsonify({
         'message': str(original_error),

--- a/app/json_response.py
+++ b/app/json_response.py
@@ -70,7 +70,7 @@ def error2(original_error):
             This property is only set for errors that are handled explicitly by
             the TinyPilot frontend.
     """
-    code = original_error.code if hasattr(original_error, 'code') else None
+    code = getattr(original_error, 'code', None)
     return flask.jsonify({
         'message': str(original_error),
         'code': code,

--- a/app/json_response.py
+++ b/app/json_response.py
@@ -47,6 +47,8 @@ def success2(data={}):
 
 
 def error2(original_error):
+    code = original_error.code if hasattr(original_error, 'code') else None
     return flask.jsonify({
-        'code': type(original_error).__name__,
+        'message': str(original_error),
+        'code': code,
     })

--- a/app/json_response.py
+++ b/app/json_response.py
@@ -46,11 +46,7 @@ def success2(data={}):
     return flask.jsonify(data)
 
 
-def error2(message_prefix, original_error):
-    error_message = str(original_error)
-    if message_prefix:
-        error_message = message_prefix + ': ' + error_message
+def error2(original_error):
     return flask.jsonify({
         'code': type(original_error).__name__,
-        'message': error_message,
     })

--- a/app/json_response.py
+++ b/app/json_response.py
@@ -38,3 +38,19 @@ def error(message):
         'success': False,
         'error': message,
     })
+
+
+# The default dictionary is okay because we're not modifying it.
+# pylint: disable=dangerous-default-value
+def success2(data={}):
+    return flask.jsonify(data)
+
+
+def error2(message_prefix, original_error):
+    error_message = str(original_error)
+    if message_prefix:
+        error_message = message_prefix + ': ' + error_message
+    return flask.jsonify({
+        'code': type(original_error).__name__,
+        'message': error_message,
+    })

--- a/app/json_response.py
+++ b/app/json_response.py
@@ -1,6 +1,6 @@
 import flask
 
-# We are currently migration from success/error to success2/error2.
+# We are currently migrating from success/error to success2/error2.
 # The former will be eventually removed and the latter renamed.
 
 

--- a/app/request_parsers/errors.py
+++ b/app/request_parsers/errors.py
@@ -11,6 +11,7 @@ class MissingFieldError(Error):
 
 
 class InvalidHostnameError(Error):
+    code = "INVALID_HOSTNAME"
     pass
 
 

--- a/app/request_parsers/errors.py
+++ b/app/request_parsers/errors.py
@@ -12,7 +12,6 @@ class MissingFieldError(Error):
 
 class InvalidHostnameError(Error):
     code = "INVALID_HOSTNAME"
-    pass
 
 
 class InvalidVideoFpsError(Error):

--- a/app/request_parsers/hostname.py
+++ b/app/request_parsers/hostname.py
@@ -9,7 +9,5 @@ def parse_hostname(request):
     hostname = message['hostname']
     if not hostname_validator.validate(hostname):
         raise errors.InvalidHostnameError(
-            'Hostnames can only contain the letters a-z, digits and dashes'
-            ' (it cannot start with a dash, though). It must contain 1-63'
-            ' characters and cannot be "localhost".')
+            'The hostname contains invalid characters.')
     return hostname

--- a/app/static/js/controllers.js
+++ b/app/static/js/controllers.js
@@ -275,9 +275,9 @@
       .then(processJsonResponse)
       .then((hostnameResponse) => {
         if (!hostnameResponse.hasOwnProperty("hostname")) {
-          return Promise.reject(new Error("Missing expected hostname field"));
+          throw new ControllerError("Missing expected hostname field");
         }
-        return Promise.resolve(hostnameResponse.hostname);
+        return hostnameResponse.hostname;
       });
   }
 

--- a/app/static/js/controllers.js
+++ b/app/static/js/controllers.js
@@ -65,7 +65,7 @@
     /**
      * @param details string with the original error message.
      * @param code (optional) string with the error code, or `undefined` for
-     *             non-application errors.
+     *             non-application or unknown errors.
      */
     constructor(details, code) {
       super(details);

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -237,7 +237,7 @@
               }
               this._handleHostnameChangeFailure({
                 title: "Failed to Change Hostname",
-                details: error.details,
+                details: error,
               });
             });
         }

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -224,7 +224,7 @@
               return this._waitForReboot(redirectURL);
             })
             .catch((error) => {
-              if (error.code === "InvalidHostnameError") {
+              if (error.code === "INVALID_HOSTNAME") {
                 // Display validation errors inline in order to make it more
                 // convenient for the user to correct them.
                 this.inputError =

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -224,17 +224,20 @@
               return this._waitForReboot(redirectURL);
             })
             .catch((error) => {
-              if (error.toString().toLowerCase().includes("invalid input")) {
+              if (error.code === "InvalidHostnameError") {
                 // Display validation errors inline in order to make it more
                 // convenient for the user to correct them.
-                // TODO(jotaen): Rely on the HTTP status code once we have that
-                this.inputError = error.toString();
+                this.inputError =
+                  "Invalid hostname: it can only contain the " +
+                  "letters a-z, digits and dashes (it cannot start with a " +
+                  "dash, though). It must contain 1-63 characters and cannot " +
+                  'be "localhost".';
                 this.state = "prompt";
                 return;
               }
               this._handleHostnameChangeFailure({
                 title: "Failed to Change Hostname",
-                details: error,
+                details: error.details,
               });
             });
         }

--- a/app/templates/custom-elements/error-dialog.html
+++ b/app/templates/custom-elements/error-dialog.html
@@ -55,11 +55,12 @@
 
         /**
          * @param title   A concise summary of the error.
-         * @param message (optional) A user-friendly and helpful message that
-         *                (ideally) gives the user some guidance what to do
+         * @param message (string, optional) A user-friendly and helpful message
+         *                that ideally gives the user some guidance what to do
          *                now. Defaults to a generic `DEFAULT_MESSAGE`.
-         * @param details (optional) The technical error details, e.g. the
-         *                original error message from the API or library call.
+         * @param details (string|Error, optional) The technical error details,
+         *                e.g. the original error message from the API or
+         *                library call.
          */
         setup({ title, message = this.DEFAULT_MESSAGE, details = "" }) {
           this.shadowRoot.getElementById("title").innerText = title;


### PR DESCRIPTION
We are currently using HTTP status code 200 all the way for API responses and rely on a custom JSON structure to distinguish an error from a success. (See also https://github.com/mtlynch/tinypilot/issues/506.)

This PR proposes a new internal convention for JSON responses:

- Rely on HTTP status code as the primary indicator whether a request succeeded or not. `2xx` is a success, anything else is treated as failure.
- Error responses follow a uniform pattern: `{ code: "…", message: "…" }`. The purpose of `code` is to allow us to handle specific cases programatically. (It’s currently the name of the error, but we might want to set it explicitly.)
- The frontend should be in charge of assembling any user-facing messages, because it’s the frontend’s responsibility how things are phrased or presented to the user. The backend errors can be kept simple, since we don’t offer a public API that is consumed by third-parties.
- I think we don’t need to explain the response structure all over again in the docstrings of the API endpoints. I would say it’s fair to assume that all endpoints deliver JSON and adhere to the common error structure. (This should be documented in one central place, maybe.)