### PR TITLE
Frontend controller: Include original errors / texts when handling response errors

### DIFF
--- a/app/static/js/controllers.js
+++ b/app/static/js/controllers.js
@@ -86,8 +86,11 @@
   async function processJsonResponse(response) {
     const contentType = response.headers.get("content-type") || "";
     if (!contentType.includes("application/json")) {
+      const status = `${response.status} ${response.statusText}`;
+      const bodyText = await response.text();
       throw new ControllerError(
-        "Malformed API response, content type must be JSON"
+        "Malformed API response, content type must be JSON.\n" +
+          `Response status: ${status}\n\n${bodyText}`
       );
     }
 
@@ -96,7 +99,7 @@
       jsonBody = await response.json();
     } catch (jsonParseError) {
       throw new ControllerError(
-        "Malformed API response, JSON body cannot be parsed"
+        "Malformed API response, JSON body cannot be parsed.\n" + jsonParseError
       );
     }
 


### PR DESCRIPTION
Include context information when returning the error from `processJsonResponse`:

## First case (non JSON)
<img width="825" alt="Screenshot 2021-05-07 at 19 33 46" src="https://user-images.githubusercontent.com/3618384/117487518-79843100-af6b-11eb-9736-e08e5f021669.png">

## Second case (JSON parsing error)
In this case we don’t have the original body anymore and we can’t easily retrieve it, because you can’t consume the response stream multiple times. I suppose it should be fine anyway, because that kind of error should be very rare.
<img width="826" alt="Screenshot 2021-05-07 at 19 41 05" src="https://user-images.githubusercontent.com/3618384/117488042-2eb6e900-af6c-11eb-85f5-97e572797aa4.png">
