### PR TITLE
Remove deprecated functions

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -40,9 +40,9 @@ def shutdown_post():
     """
     try:
         local_system.shutdown()
-        return json_response.success2()
+        return json_response.success()
     except local_system.Error as e:
-        return json_response.error2(e), 500
+        return json_response.error(e), 500
 
 
 @api_blueprint.route('/restart', methods=['POST'])
@@ -54,9 +54,9 @@ def restart_post():
     """
     try:
         local_system.restart()
-        return json_response.success2()
+        return json_response.success()
     except local_system.Error as e:
-        return json_response.error2(e), 500
+        return json_response.error(e), 500
 
 
 @api_blueprint.route('/update', methods=['GET'])
@@ -78,8 +78,8 @@ def update_get():
 
     status, error = update.status.get()
     if error:
-        return json_response.error2(error), 500
-    return json_response.success2({'status': str(status)})
+        return json_response.error(error), 500
+    return json_response.success({'status': str(status)})
 
 
 @api_blueprint.route('/update', methods=['PUT'])
@@ -99,8 +99,8 @@ def update_put():
         # If an update is already in progress, treat it as success.
         pass
     except update.launcher.Error as e:
-        return json_response.error2(e), 500
-    return json_response.success2()
+        return json_response.error(e), 500
+    return json_response.success()
 
 
 @api_blueprint.route('/version', methods=['GET'])
@@ -119,9 +119,9 @@ def version_get():
         Returns error object on failure.
     """
     try:
-        return json_response.success2({'version': version.local_version()})
+        return json_response.success({'version': version.local_version()})
     except version.Error as e:
-        return json_response.error2(e), 500
+        return json_response.error(e), 500
 
 
 @api_blueprint.route('/latestRelease', methods=['GET'])
@@ -140,9 +140,9 @@ def latest_release_get():
         Returns error object on failure.
     """
     try:
-        return json_response.success2({'version': version.latest_version()})
+        return json_response.success({'version': version.latest_version()})
     except version.Error as e:
-        return json_response.error2(e), 500
+        return json_response.error(e), 500
 
 
 @api_blueprint.route('/hostname', methods=['GET'])
@@ -161,9 +161,9 @@ def hostname_get():
         Returns an error object on failure.
     """
     try:
-        return json_response.success2({'hostname': hostname.determine()})
+        return json_response.success({'hostname': hostname.determine()})
     except hostname.Error as e:
-        return json_response.error2(e), 500
+        return json_response.error(e), 500
 
 
 @api_blueprint.route('/hostname', methods=['PUT'])
@@ -182,11 +182,11 @@ def hostname_set():
     try:
         new_hostname = request_parsers.hostname.parse_hostname(flask.request)
         hostname.change(new_hostname)
-        return json_response.success2()
+        return json_response.success()
     except request_parsers.errors.Error as e:
-        return json_response.error2(e), 400
+        return json_response.error(e), 400
     except hostname.Error as e:
-        return json_response.error2(e), 500
+        return json_response.error(e), 500
 
 
 @api_blueprint.route('/status', methods=['GET'])
@@ -199,7 +199,7 @@ def status_get():
     Returns:
         Empty response, which implies the server is up and running.
     """
-    response = json_response.success2()
+    response = json_response.success()
     response.headers['Access-Control-Allow-Origin'] = '*'
     return response
 
@@ -222,12 +222,12 @@ def settings_video_fps_get():
     try:
         video_fps = update.settings.load().ustreamer_desired_fps
     except update.settings.LoadSettingsError as e:
-        return json_response.error2(e), 200
+        return json_response.error(e), 200
     # Note: Default values are not set in the settings file. So when the
     # values are unset, we must respond with the correct default value.
     if video_fps is None:
         video_fps = video_settings.DEFAULT_FPS
-    return json_response.success2({'videoFps': video_fps})
+    return json_response.success({'videoFps': video_fps})
 
 
 @api_blueprint.route('/settings/video/fps', methods=['PUT'])
@@ -254,10 +254,10 @@ def settings_video_fps_put():
             settings.ustreamer_desired_fps = video_fps
         update.settings.save(settings)
     except request_parsers.errors.InvalidVideoFpsError as e:
-        return json_response.error2(e), 400
+        return json_response.error(e), 400
     except update.settings.SaveSettingsError as e:
-        return json_response.error2(e), 500
-    return json_response.success2()
+        return json_response.error(e), 500
+    return json_response.success()
 
 
 @api_blueprint.route('/settings/video/jpeg_quality', methods=['GET'])
@@ -278,12 +278,12 @@ def settings_video_jpeg_quality_get():
     try:
         video_jpeg_quality = update.settings.load().ustreamer_quality
     except update.settings.LoadSettingsError as e:
-        return json_response.error2(e), 500
+        return json_response.error(e), 500
     # Note: Default values are not set in the settings file. So when the
     # values are unset, we must respond with the correct default value.
     if video_jpeg_quality is None:
         video_jpeg_quality = video_settings.DEFAULT_JPEG_QUALITY
-    return json_response.success2({'videoJpegQuality': video_jpeg_quality})
+    return json_response.success({'videoJpegQuality': video_jpeg_quality})
 
 
 @api_blueprint.route('/settings/video/jpeg_quality', methods=['PUT'])
@@ -311,10 +311,10 @@ def settings_video_jpeg_quality_put():
             settings.ustreamer_quality = video_jpeg_quality
         update.settings.save(settings)
     except request_parsers.errors.InvalidVideoJpegQualityError as e:
-        return json_response.error2(e), 400
+        return json_response.error(e), 400
     except update.settings.SaveSettingsError as e:
-        return json_response.error2(e), 500
-    return json_response.success2()
+        return json_response.error(e), 500
+    return json_response.success()
 
 
 @api_blueprint.route('/settings/video/apply', methods=['POST'])
@@ -327,5 +327,5 @@ def settings_video_apply_post():
     try:
         video_settings.apply()
     except video_settings.Error as e:
-        return json_response.error2(e), 500
-    return json_response.success2()
+        return json_response.error(e), 500
+    return json_response.success()

--- a/app/json_response.py
+++ b/app/json_response.py
@@ -1,51 +1,20 @@
 import flask
 
-# We are currently migrating from success/error to success2/error2.
-# The former will be eventually removed and the latter renamed.
 
-
-# The default dictionary is okay because we're not modifying it.
-# pylint: disable=dangerous-default-value
-def success(fields={}):
-    """A JSON response for a successful request. (DEPRECATED, use `success2`)
-
-    Args:
-        fields: Dictionary with JSON properties to include.
-
-    Returns:
-        A `flask.Response` object with JSON body. The JSON structure contains a
-        `success` property (which is `true`) and an `error` property (which is
-        `null`). The additional fields given are merged into the JSON output.
-    """
-    response = {
-        'success': True,
-        'error': None,
-    }
-    for key, val in fields.items():
-        response[key] = val
-    return flask.jsonify(response)
-
-
-def error(message):
-    """A JSON response for a failed request. (DEPRECATED, use `error2`)
-
-    Args:
-        message: String containing the error message.
-
-    Returns:
-        A `flask.Response` object with JSON body. The JSON structure contains a
-        `success` property (which is `false`) and an `error` property (which is
-        a string containing the error message).
-    """
-    return flask.jsonify({
-        'success': False,
-        'error': message,
-    })
-
-
-# The default dictionary is okay because we're not modifying it.
+# TODO(jotaen) Only needed for compatibility with Pro. Remove eventually.
 # pylint: disable=dangerous-default-value
 def success2(data={}):
+    return success(data)
+
+
+# TODO(jotaen) Only needed for compatibility with Pro. Remove eventually.
+def error2(err):
+    return error(err)
+
+
+# The default dictionary is okay because we're not modifying it.
+# pylint: disable=dangerous-default-value
+def success(data={}):
     """A JSON response for a successful request.
 
     Args:
@@ -57,7 +26,7 @@ def success2(data={}):
     return flask.jsonify(data)
 
 
-def error2(original_error):
+def error(original_error):
     """A JSON response for a failed request.
 
     Args:

--- a/app/main.py
+++ b/app/main.py
@@ -51,7 +51,7 @@ app.register_blueprint(views.views_blueprint)
 
 @app.errorhandler(flask_wtf.csrf.CSRFError)
 def handle_csrf_error(error):
-    return json_response.error2(error), 403
+    return json_response.error(error), 403
 
 
 @app.after_request
@@ -71,7 +71,7 @@ def handle_error(e):
     code = 500
     if isinstance(e, exceptions.HTTPException):
         code = e.code
-    return json_response.error2(e), code
+    return json_response.error(e), code
 
 
 def main():

--- a/app/static/js/controllers.js
+++ b/app/static/js/controllers.js
@@ -29,36 +29,6 @@
       });
   }
 
-  // DEPRECATED: delete once we have finished the migration in the pro repo.
-  function readHttpJsonResponse(response) {
-    const contentType = response.headers.get("content-type");
-    const isJson =
-      contentType && contentType.indexOf("application/json") !== -1;
-
-    // Success case is an HTTP 200 response and a JSON body.
-    if (response.status === 200 && isJson) {
-      return Promise.resolve(response.json());
-    }
-
-    // If this is JSON, try to read the error field.
-    if (isJson) {
-      return response.json().then((responseJson) => {
-        if (responseJson.hasOwnProperty("error")) {
-          return Promise.reject(new Error(responseJson.error));
-        }
-        return Promise.reject(new Error("Unknown error"));
-      });
-    }
-
-    return response.text().then((text) => {
-      if (text) {
-        return Promise.reject(new Error(text));
-      } else {
-        return Promise.reject(new Error(response.statusText));
-      }
-    });
-  }
-
   class ControllerError extends Error {
     /**
      * @param details string with the original error message.
@@ -110,17 +80,6 @@
       jsonBody.message || "Unknown error: " + JSON.stringify(jsonBody),
       jsonBody.code
     );
-  }
-
-  // DEPRECATED: delete once we have finished the migration in the pro repo.
-  function checkJsonSuccess(response) {
-    if (response.hasOwnProperty("error") && response.error) {
-      return Promise.reject(new Error(response.error));
-    }
-    if (!response.hasOwnProperty("success") || !response.success) {
-      return Promise.reject(new Error("Unknown error"));
-    }
-    return Promise.resolve(response);
   }
 
   function getLatestRelease() {


### PR DESCRIPTION
Complete the migration of the API responses:

- Rename `success2`→`success`
- Remove deprecated functions
- Keep a proxy version of `success2` and `error2`, otherwise it will break Pro upon merging.