### PR TITLE
Fix modifier keys that don't work in combination with mouse clicks.

### DIFF
--- a/app/hid/keyboard.py
+++ b/app/hid/keyboard.py
@@ -1,11 +1,4 @@
-from hid import keycodes as hid
 from hid import write as hid_write
-
-_MODIFIER_KEYCODES = [
-    hid.KEYCODE_LEFT_CTRL, hid.KEYCODE_LEFT_SHIFT, hid.KEYCODE_LEFT_ALT,
-    hid.KEYCODE_LEFT_META, hid.KEYCODE_RIGHT_CTRL, hid.KEYCODE_RIGHT_SHIFT,
-    hid.KEYCODE_RIGHT_ALT, hid.KEYCODE_RIGHT_META
-]
 
 
 def send_keystroke(keyboard_path, control_keys, hid_keycode):
@@ -14,9 +7,9 @@ def send_keystroke(keyboard_path, control_keys, hid_keycode):
     buf[2] = hid_keycode
     hid_write.write_to_hid_interface(keyboard_path, buf)
 
-    # If it's not a modifier keycode, add a message indicating that the key
-    # should be released after it is sent.
-    if hid_keycode not in _MODIFIER_KEYCODES:
+    # If it's a normal keycode (i.e. not a standalone modifier key), add a
+    # message indicating that the key should be released after it is sent.
+    if hid_keycode:
         release_keys(keyboard_path)
 
 

--- a/app/hid/keyboard_test.py
+++ b/app/hid/keyboard_test.py
@@ -1,6 +1,5 @@
 import tempfile
 import unittest
-from unittest import mock
 
 from hid import keyboard
 from hid import keycodes
@@ -8,8 +7,7 @@ from hid import keycodes
 
 class KeyboardTest(unittest.TestCase):
 
-    @mock.patch.object(keyboard, 'release_keys')
-    def test_send_hid_keycode_to_hid_interface(self, mock_release_keys):
+    def test_send_hid_keycode_to_hid_interface(self):
         with tempfile.NamedTemporaryFile() as input_file:
             keyboard.send_keystroke(
                 keyboard_path=input_file.name,
@@ -17,12 +15,12 @@ class KeyboardTest(unittest.TestCase):
                 hid_keycode=keycodes.KEYCODE_A,
             )
             input_file.seek(0)
-            self.assertEqual(b'\x00\x00\x04\x00\x00\x00\x00\x00',
-                             input_file.read())
-            mock_release_keys.assert_called_once()
+            # Press the key then release the key.
+            self.assertEqual(
+                b'\x00\x00\x04\x00\x00\x00\x00\x00'
+                b'\x00\x00\x00\x00\x00\x00\x00\x00', input_file.read())
 
-    @mock.patch.object(keyboard, 'release_keys')
-    def test_send_control_key_to_hid_interface(self, mock_release_keys):
+    def test_send_control_key_to_hid_interface(self):
         with tempfile.NamedTemporaryFile() as input_file:
             keyboard.send_keystroke(
                 keyboard_path=input_file.name,
@@ -30,13 +28,12 @@ class KeyboardTest(unittest.TestCase):
                 hid_keycode=keycodes.KEYCODE_NONE,
             )
             input_file.seek(0)
+            # Press the key, but do not release the key. This is to allow for
+            # shift+click type behavior.
             self.assertEqual(b'\x02\x00\x00\x00\x00\x00\x00\x00',
                              input_file.read())
-            mock_release_keys.assert_not_called()
 
-    @mock.patch.object(keyboard, 'release_keys')
-    def test_send_control_key_and_hid_keycode_to_hid_interface(
-            self, mock_release_keys):
+    def test_send_control_key_and_hid_keycode_to_hid_interface(self):
         with tempfile.NamedTemporaryFile() as input_file:
             keyboard.send_keystroke(
                 keyboard_path=input_file.name,
@@ -44,9 +41,10 @@ class KeyboardTest(unittest.TestCase):
                 hid_keycode=keycodes.KEYCODE_A,
             )
             input_file.seek(0)
-            self.assertEqual(b'\x02\x00\x04\x00\x00\x00\x00\x00',
-                             input_file.read())
-            mock_release_keys.assert_called_once()
+            # Press the key then release the key.
+            self.assertEqual(
+                b'\x02\x00\x04\x00\x00\x00\x00\x00'
+                b'\x00\x00\x00\x00\x00\x00\x00\x00', input_file.read())
 
     def test_send_release_keys_to_hid_interface(self):
         with tempfile.NamedTemporaryFile() as input_file:

--- a/app/hid/keyboard_test.py
+++ b/app/hid/keyboard_test.py
@@ -1,0 +1,55 @@
+import tempfile
+import unittest
+from unittest import mock
+
+from hid import keyboard
+from hid import keycodes
+
+
+class KeyboardTest(unittest.TestCase):
+
+    @mock.patch.object(keyboard, 'release_keys')
+    def test_send_hid_keycode_to_hid_interface(self, mock_release_keys):
+        with tempfile.NamedTemporaryFile() as input_file:
+            keyboard.send_keystroke(
+                keyboard_path=input_file.name,
+                control_keys=keycodes.KEYCODE_NONE,
+                hid_keycode=keycodes.KEYCODE_A,
+            )
+            input_file.seek(0)
+            self.assertEqual(b'\x00\x00\x04\x00\x00\x00\x00\x00',
+                             input_file.read())
+            mock_release_keys.assert_called_once()
+
+    @mock.patch.object(keyboard, 'release_keys')
+    def test_send_control_key_to_hid_interface(self, mock_release_keys):
+        with tempfile.NamedTemporaryFile() as input_file:
+            keyboard.send_keystroke(
+                keyboard_path=input_file.name,
+                control_keys=keycodes.MODIFIER_LEFT_SHIFT,
+                hid_keycode=keycodes.KEYCODE_NONE,
+            )
+            input_file.seek(0)
+            self.assertEqual(b'\x02\x00\x00\x00\x00\x00\x00\x00',
+                             input_file.read())
+            mock_release_keys.assert_not_called()
+
+    @mock.patch.object(keyboard, 'release_keys')
+    def test_send_control_key_and_hid_keycode_to_hid_interface(
+            self, mock_release_keys):
+        with tempfile.NamedTemporaryFile() as input_file:
+            keyboard.send_keystroke(
+                keyboard_path=input_file.name,
+                control_keys=keycodes.MODIFIER_LEFT_SHIFT,
+                hid_keycode=keycodes.KEYCODE_A,
+            )
+            input_file.seek(0)
+            self.assertEqual(b'\x02\x00\x04\x00\x00\x00\x00\x00',
+                             input_file.read())
+            mock_release_keys.assert_called_once()
+
+    def test_send_release_keys_to_hid_interface(self):
+        with tempfile.NamedTemporaryFile() as input_file:
+            keyboard.release_keys(keyboard_path=input_file.name)
+            self.assertEqual(b'\x00\x00\x00\x00\x00\x00\x00\x00',
+                             input_file.read())

--- a/app/hid/write.py
+++ b/app/hid/write.py
@@ -14,7 +14,7 @@ class WriteError(Error):
 
 def _write_to_hid_interface_immediately(hid_path, buffer):
     try:
-        with open(hid_path, 'wb+') as hid_handle:
+        with open(hid_path, 'ab+') as hid_handle:
             hid_handle.write(bytearray(buffer))
     except BlockingIOError:
         logger.error(


### PR DESCRIPTION
`hid.keyboard.send_keystroke` was always releasing the key after it has been pressed. This is because a keycode is not actually set when a modifier is pressed on it's own. This stopped us from doing things like holding in the shift key and clicking with the mouse to highlight text. [Demo video](https://www.loom.com/share/8a4629a3a70f459d9869cd493e04289a).

Fixes #620

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mtlynch/tinypilot/692)
<!-- Reviewable:end -->
