### PR TITLE
Debug Logs Overlay: redesign in-overlay buttons

### DIFF
--- a/app/templates/custom-elements/debug-dialog.html
+++ b/app/templates/custom-elements/debug-dialog.html
@@ -37,7 +37,7 @@
     }
 
     #url-success .url-wrapper {
-      margin: 3rem 0;
+      margin: 1rem 0;
     }
 
     #url-success .url {
@@ -64,6 +64,7 @@
       </button>
     </div>
     <p class="logs monospace"></p>
+    <button class="close-btn" type="button">Close</button>
   </div>
 
   <!-- Get Shareable URL -->
@@ -80,6 +81,7 @@
         Copy to Clipboard
       </button>
     </div>
+    <button class="close-btn" type="button">Close</button>
   </div>
 </template>
 
@@ -105,6 +107,9 @@
 
         connectedCallback() {
           this.shadowRoot.appendChild(template.content.cloneNode(true));
+          this.shadowRoot.querySelectorAll(".close-btn").forEach((el) => {
+            el.addEventListener("click", this._close);
+          });
           this.shadowRoot
             .querySelector("#logs-success .share-btn")
             .addEventListener("click", this._getUrl);

--- a/app/templates/custom-elements/debug-dialog.html
+++ b/app/templates/custom-elements/debug-dialog.html
@@ -17,6 +17,14 @@
       display: block;
     }
 
+    .action-buttons {
+      text-align: left;
+    }
+
+    .action-buttons button {
+      margin: 0 1rem 0 0;
+    }
+
     #logs-success .logs {
       padding: 0.25rem 0.5rem;
       background-color: white;
@@ -47,14 +55,15 @@
 
   <div id="logs-success">
     <h3>Debug Logs</h3>
+    <div class="action-buttons">
+      <button class="share-btn btn-action btn-small" type="button">
+        Get Shareable URL
+      </button>
+      <button class="copy-btn btn-action btn-small" type="button">
+        Copy to Clipboard
+      </button>
+    </div>
     <p class="logs monospace"></p>
-    <button class="share-btn btn-success" type="button">
-      Get Shareable URL
-    </button>
-    <button class="copy-btn btn-success" type="button">
-      Copy to Clipboard
-    </button>
-    <button class="close-btn" type="button">Close</button>
   </div>
 
   <!-- Get Shareable URL -->
@@ -67,11 +76,10 @@
     <h3>Debug Logs</h3>
     <div class="url-wrapper">
       <a class="url"></a>
+      <button class="copy-btn btn-action" type="button">
+        Copy to Clipboard
+      </button>
     </div>
-    <button class="copy-btn btn-success" type="button">
-      Copy to clipboard
-    </button>
-    <button class="close-btn" type="button">Close</button>
   </div>
 </template>
 
@@ -97,9 +105,6 @@
 
         connectedCallback() {
           this.shadowRoot.appendChild(template.content.cloneNode(true));
-          this.shadowRoot.querySelectorAll(".close-btn").forEach((el) => {
-            el.addEventListener("click", this._close);
-          });
           this.shadowRoot
             .querySelector("#logs-success .share-btn")
             .addEventListener("click", this._getUrl);

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -42,7 +42,7 @@
             id="change-hostname-dialog"
           ></change-hostname-dialog>
         </overlay-panel>
-        <overlay-panel id="debug-overlay">
+        <overlay-panel id="debug-overlay" close-button="true">
           <debug-dialog id="debug-dialog"></debug-dialog>
         </overlay-panel>
         <overlay-panel id="video-settings-overlay">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -42,7 +42,7 @@
             id="change-hostname-dialog"
           ></change-hostname-dialog>
         </overlay-panel>
-        <overlay-panel id="debug-overlay" close-button="true">
+        <overlay-panel id="debug-overlay">
           <debug-dialog id="debug-dialog"></debug-dialog>
         </overlay-panel>
         <overlay-panel id="video-settings-overlay">


### PR DESCRIPTION
Based on https://github.com/mtlynch/tinypilot/pull/698, apply the changes to the debug logs dialog. ~(Waiting to be rebased.)~ Rebased.

<img width="646" alt="Screenshot 2021-05-18 at 19 24 06" src="https://user-images.githubusercontent.com/3618384/118697199-54b37780-b80f-11eb-8ed4-86be58344a45.png">

<img width="879" alt="Screenshot 2021-05-18 at 19 32 52" src="https://user-images.githubusercontent.com/3618384/118697687-dc00eb00-b80f-11eb-9576-d5f152d3dc48.png">


