### PR TITLE
Introduce general `x` button for closing overlays

### DIFF
--- a/app/templates/custom-elements/overlay-panel.html
+++ b/app/templates/custom-elements/overlay-panel.html
@@ -21,10 +21,27 @@
     }
 
     #panel {
+      position: relative;
       max-width: 800px;
       margin: 100px auto;
       padding: 2rem;
       text-align: center;
+    }
+
+    #close-button {
+      display: block;
+      position: absolute;
+      top: 0;
+      right: 0;
+      width: 2.3rem;
+      padding: 0;
+      margin: 0;
+      opacity: 0.5;
+    }
+
+    #close-button svg {
+      display: block;
+      margin: 0.3rem;
     }
 
     :host([variant="default"]) #panel,
@@ -41,6 +58,14 @@
   </style>
 
   <div id="panel">
+    <button id="close-button" title="Close Overlay">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18">
+        <path
+          fill="#fff"
+          d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
+        />
+      </svg>
+    </button>
     <slot></slot>
   </div>
 </template>
@@ -61,6 +86,9 @@
           this.shadowRoot.addEventListener("dialog-closed", () =>
             this.show(false)
           );
+          this.shadowRoot
+            .getElementById("close-button")
+            .addEventListener("click", () => this.show(false));
         }
 
         show(isShown = true) {


### PR DESCRIPTION
I’m parking this here for now, since I’m actually working on something else right now. I’d like to come back to this, though, because I think this might be a useful improvement. It’s a spin-off of https://github.com/mtlynch/tinypilot/pull/698 and https://github.com/tiny-pilot/tinypilot-pro/issues/122.

---

Currently you need to scroll all the way to the bottom to close an overlay, which can be annoying in longer overlays (potentially Debug Logs and Virtual Media).

We could introduce an `x` button in the top right to make closing more convenient:

<img width="923" alt="Screenshot 2021-05-18 at 19 13 28" src="https://user-images.githubusercontent.com/3618384/118695159-29c82400-b80d-11eb-837a-ebd12d37bbe1.png">

## TBD
- This can either appear on all overlays by default, or it can appear only for specific cases.
- It can make the “Close” button at the bottom superfluous, it can also just be an addendum.