### PR TITLE
Fail fast when an error occurs during an update.

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -67,19 +67,18 @@ def update_get():
         On success, a JSON data structure with the following properties:
         status: str describing the status of the job. Can be one of
                 ["NOT_RUNNING", "DONE", "IN_PROGRESS"].
+        updateError: str of the error that occured while updating. If no error
+                     occured, then this will be null.
 
         Example:
         {
-            "status": "NOT_RUNNING"
+            "status": "NOT_RUNNING",
+            "updateError": null
         }
-
-        Returns error object on failure.
     """
 
     status, error = update.status.get()
-    if error:
-        return json_response.error(error), 500
-    return json_response.success({'status': str(status)})
+    return json_response.success({'status': str(status), 'updateError': error})
 
 
 @api_blueprint.route('/update', methods=['PUT'])

--- a/app/static/js/controllers.js
+++ b/app/static/js/controllers.js
@@ -171,11 +171,14 @@
       redirect: "error",
     })
       .then(processJsonResponse)
-      .then((updateResponse) => {
-        if (!updateResponse.hasOwnProperty("status")) {
+      .then((data) => {
+        if (!data.hasOwnProperty("status")) {
           throw new ControllerError("Missing expected status field");
         }
-        return updateResponse.status;
+        if (!data.hasOwnProperty("updateError")) {
+          throw new ControllerError("Missing expected updateError field");
+        }
+        return { status: data.status, updateError: data.updateError };
       });
   }
 

--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -154,11 +154,13 @@
         _waitForUpdateToFinish() {
           return poll({
             fn: controllers.getUpdateStatus,
-            validate: (status) => {
-              return status === "DONE";
-            },
+            validate: (data) => data.status === "DONE" || data.updateError,
             interval: 2 * 1000,
             timeout: 300 * 1000,
+          }).then((data) => {
+            if (data.updateError) {
+              return Promise.reject(data.updateError);
+            }
           });
         }
 


### PR DESCRIPTION
[Demo video](https://www.loom.com/share/b87373a336a84996ab3c9fc04f08ea17).

# Noteworthy changes:
1. Backend: Added an `updateError` field to the `/api/update` API endpoint response.
2. Fontend: Throw an error immediately when the `updateError` is not null.

Fixes #649 