### PR TITLE
Declare global style for textual input fields

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -90,3 +90,11 @@ img {
 .question-icon {
   max-width: 20px;
 }
+
+input[type="text"],
+input[type="password"] {
+  padding: 0.5rem;
+  font-family: inherit;
+  font-size: inherit;
+  border: 1px solid #666;
+}

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -27,8 +27,7 @@
     }
 
     #hostname-input {
-      margin: 0 auto;
-      padding: 0.3rem;
+      margin-left: 0.5rem;
     }
 
     .input-container {


### PR DESCRIPTION
It’s useful to declare the styling of the input field globally, so that it’s always consistent. In the community version we only have one text input field (change hostname overlay), but in Pro we have more (security overlay and login screen), so I need it for that primarily (https://github.com/tiny-pilot/tinypilot-pro/pull/145).

While on it, I quickly tweaked the spacing between label and input field in the hostname overlay. I don’t know why I originally added `margin: 0 auto` there, that doesn’t make any sense since the elements are inline.

<img width="864" alt="Screenshot 2021-05-21 at 18 06 16" src="https://user-images.githubusercontent.com/3618384/119169056-e0244700-ba61-11eb-8a98-dfd4351645aa.png">
