### PR TITLE
Proposal: improved and reusable control flows in overlay dialogs

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -18,6 +18,7 @@
   --brand-creme-light: hsl(var(--brand-hue-yellow), 60%, 97%);
 
   --brand-blue: hsl(var(--brand-hue-blue), 55%, 55%);
+  --brand-blue-light: hsl(var(--brand-hue-blue), 40%, 98%);
   --brand-blue-bright: hsl(var(--brand-hue-blue), 90%, 67%);
 
   --brand-red: hsl(var(--brand-hue-red), 55%, 40%);

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -34,10 +34,11 @@ function isElementShown(id) {
 /**
  * @see the `setup` method in error-dialog.html for the `errorInfo` param
  */
+const errorOverlay = document.getElementById("error-overlay");
 function showError(errorInfo) {
   console.error(`${errorInfo.title}:\n${errorInfo.details}`);
-  document.getElementById("error-dialog").setup(errorInfo);
-  document.getElementById("error-overlay").show();
+  errorOverlay.show();
+  errorOverlay.error(errorInfo);
 }
 
 function isKeyPressed(code) {
@@ -304,9 +305,11 @@ menuBar.addEventListener("update-dialog-requested", () => {
   document.getElementById("update-overlay").show();
   document.getElementById("update-dialog").checkVersion();
 });
+document
+  .getElementById("change-hostname-overlay")
+  .onShow(() => document.getElementById("change-hostname-dialog").initialize());
 menuBar.addEventListener("change-hostname-dialog-requested", () => {
   document.getElementById("change-hostname-overlay").show();
-  document.getElementById("change-hostname-dialog").initialize();
 });
 menuBar.addEventListener("fullscreen-requested", () => {
   document.getElementById("remote-screen").fullscreen = true;
@@ -339,7 +342,6 @@ document
 
 const errorEvents = [
   "update-failure",
-  "change-hostname-failure",
   "shutdown-failure",
   "video-settings-failure",
   "debug-logs-failure",

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -3,23 +3,8 @@
     @import "css/style.css";
     @import "css/button.css";
 
-    #initializing,
-    #prompt,
-    #changing,
     #input-error {
       display: none;
-    }
-
-    :host([state="initializing"]) #initializing {
-      display: block;
-    }
-
-    :host([state="prompt"]) #prompt {
-      display: block;
-    }
-
-    :host([state="changing"]) #changing {
-      display: block;
     }
 
     :host([has-input-error="true"]) #input-error {
@@ -40,15 +25,7 @@
     }
   </style>
 
-  <div id="initializing">
-    <h3>Retrieving Current Hostname</h3>
-    <div>
-      <progress-spinner></progress-spinner>
-    </div>
-    <button id="cancel-initialization" type="button">Cancel</button>
-  </div>
-
-  <div id="prompt">
+  <div>
     <h3>Change Hostname</h3>
     <p>
       Enter a new hostname for TinyPilot.
@@ -63,17 +40,15 @@
     </button>
     <button id="cancel-hostname-change" type="button">Cancel</button>
   </div>
+</template>
 
-  <div id="changing">
-    <h3>Changing Hostname</h3>
-    <p>
-      Waiting for TinyPilot to reboot at
-      <a href="" id="future-location"><!-- Filled programmatically --></a>
-      <br />
-      You will be redirected automatically.
-    </p>
-    <progress-spinner></progress-spinner>
-  </div>
+<template id="hostname-change-in-progress-template">
+  <p>
+    Waiting for TinyPilot to reboot at
+    <a href="" id="future-location"><!-- Filled programmatically --></a>
+    <br />
+    You will be redirected automatically.
+  </p>
 </template>
 
 <script src="/js/util/poll.js"></script>
@@ -122,9 +97,6 @@
             changeAndRestart: this.shadowRoot.getElementById(
               "change-and-restart"
             ),
-            cancelInitialization: this.shadowRoot.getElementById(
-              "cancel-initialization"
-            ),
             cancelHostnameChange: this.shadowRoot.getElementById(
               "cancel-hostname-change"
             ),
@@ -137,20 +109,9 @@
           this.elements.changeAndRestart.addEventListener("click", () => {
             this._doChangeHostname();
           });
-          this.elements.cancelInitialization.addEventListener("click", () => {
-            this._close();
-          });
           this.elements.cancelHostnameChange.addEventListener("click", () => {
-            this._close();
+            this.dispatchEvent(new DialogClosedEvent());
           });
-        }
-
-        get state() {
-          return this.getAttribute("state");
-        }
-
-        set state(newValue) {
-          this.setAttribute("state", newValue);
         }
 
         get initialHostname() {
@@ -178,20 +139,27 @@
 
         initialize() {
           this.inputError = null;
-          this.state = "initializing";
+          this.dispatchEvent(
+            new DialogProgressStartedEvent({
+              title: "Retrieving Current Hostname",
+              isCancellable: true,
+            })
+          );
           controllers
             .determineHostname()
             .then((hostname) => {
               this.initialHostname = hostname;
               this.elements.hostnameInput.value = hostname;
               this._onInputChanged(hostname);
-              this.state = "prompt";
+              this.dispatchEvent(new DialogProgressFinishedEvent());
             })
             .catch((error) => {
-              this._handleHostnameChangeFailure({
-                title: "Failed to Determine Hostname",
-                details: error,
-              });
+              this.dispatchEvent(
+                new DialogErrorEvent({
+                  title: "Failed to Determine Hostname",
+                  details: error,
+                })
+              );
             });
         }
 
@@ -202,6 +170,11 @@
         }
 
         _doChangeHostname() {
+          this.dispatchEvent(
+            new DialogProgressStartedEvent({
+              title: "Changing Hostname",
+            })
+          );
           controllers
             .changeHostname(this.elements.hostnameInput.value)
             .then((newHostname) => {
@@ -217,9 +190,19 @@
               );
             })
             .then((redirectURL) => {
-              this.elements.futureLocation.innerText = redirectURL;
-              this.elements.futureLocation.href = redirectURL;
-              this.state = "changing";
+              const progress = document
+                .getElementById("hostname-change-in-progress-template")
+                .content.cloneNode(true);
+              progress.getElementById(
+                "future-location"
+              ).innerText = redirectURL;
+              progress.getElementById("future-location").href = redirectURL;
+              this.dispatchEvent(
+                new DialogProgressStartedEvent({
+                  title: "Changing Hostname",
+                  info: progress,
+                })
+              );
               return this._waitForReboot(redirectURL);
             })
             .catch((error) => {
@@ -231,13 +214,16 @@
                   "letters a-z, digits and dashes (it cannot start with a " +
                   "dash, though). It must contain 1-63 characters and cannot " +
                   'be "localhost".';
-                this.state = "prompt";
+                this.dispatchEvent(new DialogProgressFinishedEvent());
                 return;
               }
-              this._handleHostnameChangeFailure({
-                title: "Failed to Change Hostname",
-                details: error,
-              });
+              this.dispatchEvent(
+                new DialogErrorEvent({
+                  title: "Failed to Change Hostname",
+                  details: error,
+                  canGoBack: true,
+                })
+              );
             });
         }
 
@@ -259,35 +245,17 @@
               window.location = futureLocation;
             })
             .catch((error) => {
-              this._handleHostnameChangeFailure({
-                title: "Failed to Redirect",
-                message:
-                  "Cannot reach TinyPilot under the new hostname. The device" +
-                  "may have failed to reboot, or your browser is failing to " +
-                  " resolve the new hostname.",
-                details: error,
-              });
+              this.dispatchEvent(
+                new DialogErrorEvent({
+                  title: "Failed to Redirect",
+                  message:
+                    "Cannot reach TinyPilot under the new hostname. The device" +
+                    " may have failed to reboot, or your browser is failing to" +
+                    " resolve the new hostname.",
+                  details: error,
+                })
+              );
             });
-        }
-
-        _handleHostnameChangeFailure(errorInfo) {
-          this._close();
-          this.dispatchEvent(
-            new CustomEvent("change-hostname-failure", {
-              detail: errorInfo,
-              bubbles: true,
-              composed: true,
-            })
-          );
-        }
-
-        _close() {
-          this.dispatchEvent(
-            new CustomEvent("dialog-closed", {
-              bubbles: true,
-              composed: true,
-            })
-          );
         }
       }
     );

--- a/app/templates/custom-elements/error-dialog.html
+++ b/app/templates/custom-elements/error-dialog.html
@@ -30,6 +30,7 @@
     <div class="details-label">Details:</div>
     <pre id="details" class="monospace"></pre>
   </div>
+  <button id="go-back">Go Back</button>
   <button id="close">Close</button>
 </template>
 
@@ -47,37 +48,38 @@
         connectedCallback() {
           this.attachShadow({ mode: "open" });
           this.shadowRoot.appendChild(template.content.cloneNode(true));
-          this.close = this.close.bind(this);
           this.shadowRoot
             .getElementById("close")
-            .addEventListener("click", this.close);
+            .addEventListener("click", () =>
+              this.dispatchEvent(new DialogClosedEvent())
+            );
         }
 
         /**
-         * @param title   A concise summary of the error.
-         * @param message (string, optional) A user-friendly and helpful message
-         *                that ideally gives the user some guidance what to do
-         *                now. Defaults to a generic `DEFAULT_MESSAGE`.
-         * @param details (string|Error, optional) The technical error details,
-         *                e.g. the original error message from the API or
-         *                library call.
+         * @params See DialogErrorEvent.
          */
-        setup({ title, message = this.DEFAULT_MESSAGE, details = "" }) {
+        setup(
+          {
+            title,
+            message = this.DEFAULT_MESSAGE,
+            details = "",
+            canGoBack = false,
+          },
+          goBackFn = () => {}
+        ) {
           this.shadowRoot.getElementById("title").innerText = title;
           this.shadowRoot.getElementById("message").innerText = message;
           this.shadowRoot.getElementById("details").innerText = details;
           this.shadowRoot.getElementById(
             "details-container"
           ).style.display = details ? "block" : "none";
-        }
-
-        close() {
-          this.dispatchEvent(
-            new CustomEvent("dialog-closed", {
-              bubbles: true,
-              composed: true,
-            })
-          );
+          const backButton = this.shadowRoot.getElementById("go-back");
+          if (canGoBack) {
+            backButton.style.display = "inline";
+            backButton.onclick = goBackFn;
+          } else {
+            backButton.style.display = "none";
+          }
         }
       }
     );

--- a/app/templates/custom-elements/overlay-panel.html
+++ b/app/templates/custom-elements/overlay-panel.html
@@ -27,25 +27,114 @@
       text-align: center;
     }
 
-    :host([variant="default"]) #panel,
-    :host([variant=""]) #panel,
-    :host(:not([variant])) #panel {
+    #main-dialog,
+    #error-dialog,
+    #progress-dialog {
+      display: none;
+    }
+
+    :host([state="main"]) #main-dialog {
+      display: block;
+    }
+
+    :host([state="main"]) #panel {
       border-top: none;
       background-color: var(--brand-creme-light);
     }
 
-    :host([variant="danger"]) #panel {
+    :host([state="error"]) #error-dialog {
+      display: block;
+    }
+
+    :host([state="error"]) #panel {
       border-top: 0.4rem solid var(--brand-red-bright);
       background-color: var(--brand-red-light);
+    }
+
+    :host([state="progress"]) #progress-dialog {
+      display: block;
+    }
+
+    :host([state="progress"]) #panel {
+      border-top: 0.4rem solid var(--brand-blue);
+      background-color: var(--brand-blue-light);
     }
   </style>
 
   <div id="panel">
-    <slot></slot>
+    <slot id="main-dialog"></slot>
+    <error-dialog id="error-dialog"></error-dialog>
+    <progress-dialog id="progress-dialog"></progress-dialog>
   </div>
 </template>
 
 <script>
+  class DialogErrorEvent extends CustomEvent {
+    /**
+     * Event that causes the error dialog to be shown.
+     * @param errorInfo object with the following properties:
+     * - title (string) A concise summary of the error.
+     * - message (string, optional) A user-friendly and helpful message that
+     *   ideally gives the user some guidance what to do now. Defaults to a
+     *   generic message.
+     * - details (string|Error, optional) The technical error details, e.g. the
+     *   original error message from the API or library call.
+     * - canGoBack (boolean, optional) Whether or not to show a back button that
+     *   re-initialized the dialog via the callback specified in the `onShow`
+     *   attribute of the enclosing overlay panel.
+     */
+    constructor(errorInfo) {
+      super("dialog-error", {
+        detail: errorInfo,
+        bubbles: true,
+        composed: true,
+      });
+    }
+  }
+
+  class DialogClosedEvent extends CustomEvent {
+    /**
+     * Event that will close the overlay.
+     */
+    constructor() {
+      super("dialog-closed", {
+        bubbles: true,
+        composed: true,
+      });
+    }
+  }
+
+  class DialogProgressStartedEvent extends CustomEvent {
+    /**
+     * Event that will transition the overlay into the progress state.
+     * @param errorInfo object with the following properties:
+     * - title (string, optional) The title in title-case
+     * - isCancellable (bool, optional) Whether or not to display cancel button
+     * - info (DOMElement, optional) Additional info to display along with the
+     *   spinner.
+     */
+    constructor(progressInfo) {
+      super("dialog-progress-started", {
+        detail: progressInfo,
+        bubbles: true,
+        composed: true,
+      });
+    }
+  }
+
+  class DialogProgressFinishedEvent extends CustomEvent {
+    /**
+     * Event that will finish the progress state and reveal the original
+     * dialog again.
+     */
+    constructor() {
+      super("dialog-progress-finished", {
+        bubbles: true,
+        composed: true,
+      });
+    }
+  }
+
   (function () {
     const doc = (document._currentScript || document.currentScript)
       .ownerDocument;
@@ -57,14 +146,44 @@
         connectedCallback() {
           this.attachShadow({ mode: "open" });
           this.shadowRoot.appendChild(template.content.cloneNode(true));
+          this.onShowCallback = () => {};
+          this.elements = {
+            mainDialog: this.shadowRoot.getElementById("main-dialog"),
+            errorDialog: this.shadowRoot.getElementById("error-dialog"),
+            progressDialog: this.shadowRoot.getElementById("progress-dialog"),
+          };
           this.show = this.show.bind(this);
           this.shadowRoot.addEventListener("dialog-closed", () =>
             this.show(false)
           );
+          this.shadowRoot.addEventListener("dialog-error", (evt) =>
+            this.error(evt.detail)
+          );
+          this.shadowRoot.addEventListener("dialog-progress-started", (evt) =>
+            this.progressStart(evt.detail)
+          );
+          this.shadowRoot.addEventListener("dialog-progress-finished", () =>
+            this.progressFinished()
+          );
+        }
+
+        onShow(callbackFn) {
+          this.onShowCallback = callbackFn;
+        }
+
+        /**
+         * @param newValue string One of: main, error, progress
+         */
+        setState(newValue) {
+          this.setAttribute("state", newValue);
         }
 
         show(isShown = true) {
+          this.setState("main");
           this.setAttribute("show", isShown ? "true" : "false");
+          if (isShown) {
+            this.onShowCallback();
+          }
           this.dispatchEvent(
             new CustomEvent("overlay-toggled", {
               detail: { isShown },
@@ -76,6 +195,20 @@
 
         isShown() {
           return this.getAttribute("show") === "true";
+        }
+
+        error(errorInfo) {
+          this.elements.errorDialog.setup(errorInfo, () => this.show());
+          this.setState("error");
+        }
+
+        progressStart(progressInfo) {
+          this.elements.progressDialog.setup(progressInfo);
+          this.setState("progress");
+        }
+
+        progressFinished() {
+          this.setState("main");
         }
       }
     );

--- a/app/templates/custom-elements/progress-dialog.html
+++ b/app/templates/custom-elements/progress-dialog.html
@@ -1,0 +1,58 @@
+<template id="progress-dialog-template">
+  <style>
+    @import "css/style.css";
+
+    #cancel-button {
+      margin-top: 2rem;
+    }
+  </style>
+
+  <h3 id="title"></h3>
+  <div id="info-container"></div>
+  <div>
+    <progress-spinner></progress-spinner>
+  </div>
+  <button id="cancel-button">Cancel</button>
+</template>
+
+<script>
+  (function () {
+    const doc = (document._currentScript || document.currentScript)
+      .ownerDocument;
+    const template = doc.querySelector("#progress-dialog-template");
+
+    customElements.define(
+      "progress-dialog",
+      class extends HTMLElement {
+        connectedCallback() {
+          this.attachShadow({ mode: "open" });
+          this.shadowRoot.appendChild(template.content.cloneNode(true));
+          this.elements = {
+            title: this.shadowRoot.getElementById("title"),
+            infoContainer: this.shadowRoot.getElementById("info-container"),
+            cancelButton: this.shadowRoot.getElementById("cancel-button"),
+          };
+          this.shadowRoot
+            .getElementById("cancel-button")
+            .addEventListener("click", () =>
+              this.dispatchEvent(new DialogClosedEvent())
+            );
+        }
+
+        /**
+         * @params See DialogProgressStartedEvent.
+         */
+        setup({ title = "Please Wait", isCancellable = false, info }) {
+          this.elements.title.innerText = title;
+          this.elements.cancelButton.style.display = isCancellable
+            ? "inline"
+            : "none";
+          this.elements.infoContainer.innerText = "";
+          if (info) {
+            this.elements.infoContainer.append(info);
+          }
+        }
+      }
+    );
+  })();
+</script>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -28,9 +28,7 @@
       </div>
 
       <div class="page-content container">
-        <overlay-panel id="error-overlay" variant="danger">
-          <error-dialog id="error-dialog"></error-dialog>
-        </overlay-panel>
+        <overlay-panel id="error-overlay"></overlay-panel>
         <overlay-panel id="shutdown-overlay">
           <shutdown-dialog id="shutdown-dialog"></shutdown-dialog>
         </overlay-panel>


### PR DESCRIPTION
## Problem

As briefly outlined in https://github.com/mtlynch/tinypilot/issues/591, we have some repetitive code and redundant structures in our overlay dialogs:
- Every dialog has it its own error event type, which has to be registered individually in `app.js`. However, eventually they are all handled in the exact same way, so we don’t gain much from this flexibility.
- Once an error occurs, the user can only close the dialog. If they want to try again, they have to close the error overlay and then re-open the initial dialog via the menu.
- Every dialog has its own implementation of progress state, even though they look and work very similarly.

## Proposal

This PR exemplifies how we could refactor the overlay and dialogs to make it easier to work with them and reuse common patterns. The goal is to reduce the boilerplate when adding new dialogs and to make the control flows (events) more expressive. As example, I refactored the `<change-hostname-dialog>` so that we can see how it’ll eventually look.

- Define and document all dialog-related events globally. That way they can be neatly emitted via `this.dispatchEvent(new DialogClosedEvent())`, without having to use verbose and repetitive handler functions á la `_handleHostnameChangeFailure` or `_close`.
- Catch and handle dialog-related events in `<overlay-panel>` directly, so we don’t need to go the roundtrip via `app.js` anymore.
- Extract `<progress-dialog>` component: we use the same pattern everywhere, so it makes sense to extract and reuse it across all dialogs. That way we can also introduce its own styling variant, so that it becomes an easily recognisable pattern for users. (Blue bar at the top, slightly blue-ish background, optional extra info, optional “cancel” button.)
- Allow to go back from the error dialog to the main dialog. (Which is optional, because it doesn’t always make sense.)

The changes are modular, so we don’t have to do them all. I wanted to flesh out all my ideas anyway. Also, it’s all backwards compatible, so all existing dialogs continue to function as is. Depending on what we want to do, I’d introduce the basic refactoring separately (plus clean & wrap it up) and then refactor the dialogs one by one.

https://user-images.githubusercontent.com/3618384/119842360-e5bcd980-bf06-11eb-9441-c829818c962e.mov