### PR TITLE
(Re-)Use centrally defined event for closing dialogs

### DIFF
--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -138,10 +138,10 @@
             this._doChangeHostname();
           });
           this.elements.cancelInitialization.addEventListener("click", () => {
-            this._close();
+            this.dispatchEvent(new DialogClosedEvent());
           });
           this.elements.cancelHostnameChange.addEventListener("click", () => {
-            this._close();
+            this.dispatchEvent(new DialogClosedEvent());
           });
         }
 
@@ -271,19 +271,10 @@
         }
 
         _handleHostnameChangeFailure(errorInfo) {
-          this._close();
+          this.dispatchEvent(new DialogClosedEvent());
           this.dispatchEvent(
             new CustomEvent("change-hostname-failure", {
               detail: errorInfo,
-              bubbles: true,
-              composed: true,
-            })
-          );
-        }
-
-        _close() {
-          this.dispatchEvent(
-            new CustomEvent("dialog-closed", {
               bubbles: true,
               composed: true,
             })

--- a/app/templates/custom-elements/debug-dialog.html
+++ b/app/templates/custom-elements/debug-dialog.html
@@ -100,15 +100,15 @@
           // Ensure that these methods always refer to the correct "this",
           // regardless of where they are called.
           this.getLogs = this.getLogs.bind(this);
-          this._close = this._close.bind(this);
-          this._reset = this._reset.bind(this);
           this._getUrl = this._getUrl.bind(this);
         }
 
         connectedCallback() {
           this.shadowRoot.appendChild(template.content.cloneNode(true));
           this.shadowRoot.querySelectorAll(".close-btn").forEach((el) => {
-            el.addEventListener("click", this._close);
+            el.addEventListener("click", () =>
+              this.dispatchEvent(new DialogClosedEvent())
+            );
           });
           this.shadowRoot
             .querySelector("#logs-success .share-btn")
@@ -161,20 +161,6 @@
             });
         }
 
-        _close() {
-          this.dispatchEvent(
-            new CustomEvent("dialog-closed", {
-              bubbles: true,
-              composed: true,
-            })
-          );
-          this._reset();
-        }
-
-        _reset() {
-          this.state = null;
-        }
-
         _getUrl() {
           this.state = "url-loading";
           const text = this.shadowRoot.querySelector("#logs-success .logs")
@@ -203,7 +189,7 @@
         }
 
         _handleFailure(errorInfo) {
-          this._close();
+          this.dispatchEvent(new DialogClosedEvent());
           this.dispatchEvent(
             new CustomEvent("debug-logs-failure", {
               detail: errorInfo,

--- a/app/templates/custom-elements/error-dialog.html
+++ b/app/templates/custom-elements/error-dialog.html
@@ -47,10 +47,11 @@
         connectedCallback() {
           this.attachShadow({ mode: "open" });
           this.shadowRoot.appendChild(template.content.cloneNode(true));
-          this.close = this.close.bind(this);
           this.shadowRoot
             .getElementById("close")
-            .addEventListener("click", this.close);
+            .addEventListener("click", () =>
+              this.dispatchEvent(new DialogClosedEvent())
+            );
         }
 
         /**
@@ -69,15 +70,6 @@
           this.shadowRoot.getElementById(
             "details-container"
           ).style.display = details ? "block" : "none";
-        }
-
-        close() {
-          this.dispatchEvent(
-            new CustomEvent("dialog-closed", {
-              bubbles: true,
-              composed: true,
-            })
-          );
         }
       }
     );

--- a/app/templates/custom-elements/overlay-panel.html
+++ b/app/templates/custom-elements/overlay-panel.html
@@ -46,6 +46,18 @@
 </template>
 
 <script>
+  class DialogClosedEvent extends CustomEvent {
+    /**
+     * Event that will close the overlay.
+     */
+    constructor() {
+      super("dialog-closed", {
+        bubbles: true,
+        composed: true,
+      });
+    }
+  }
+
   (function () {
     const doc = (document._currentScript || document.currentScript)
       .ownerDocument;

--- a/app/templates/custom-elements/shutdown-dialog.html
+++ b/app/templates/custom-elements/shutdown-dialog.html
@@ -89,7 +89,7 @@
           this.shadowRoot
             .getElementById("cancel-shutdown")
             .addEventListener("click", () => {
-              this._close();
+              this.dispatchEvent(new DialogClosedEvent());
             });
         }
 
@@ -143,19 +143,10 @@
         }
 
         _handleShutdownFailure(errorInfo) {
-          this._close();
+          this.dispatchEvent(new DialogClosedEvent());
           this.dispatchEvent(
             new CustomEvent("shutdown-failure", {
               detail: errorInfo,
-              bubbles: true,
-              composed: true,
-            })
-          );
-        }
-
-        _close() {
-          this.dispatchEvent(
-            new CustomEvent("dialog-closed", {
               bubbles: true,
               composed: true,
             })

--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -104,12 +104,12 @@
           this.shadowRoot
             .getElementById("cancel-update")
             .addEventListener("click", () => {
-              this._close();
+              this.dispatchEvent(new DialogClosedEvent());
             });
           this.shadowRoot
             .getElementById("ok-latest")
             .addEventListener("click", () => {
-              this._close();
+              this.dispatchEvent(new DialogClosedEvent());
             });
           this.shadowRoot
             .getElementById("ok-finished")
@@ -251,19 +251,10 @@
         }
 
         _handleUpdateFailure(errorInfo) {
-          this._close();
+          this.dispatchEvent(new DialogClosedEvent());
           this.dispatchEvent(
             new CustomEvent("update-failure", {
               detail: errorInfo,
-              bubbles: true,
-              composed: true,
-            })
-          );
-        }
-
-        _close() {
-          this.dispatchEvent(
-            new CustomEvent("dialog-closed", {
               bubbles: true,
               composed: true,
             })

--- a/app/templates/custom-elements/video-settings-dialog.html
+++ b/app/templates/custom-elements/video-settings-dialog.html
@@ -94,7 +94,9 @@
           this.shadowRoot.appendChild(template.content.cloneNode(true));
           this.shadowRoot
             .querySelector(".close-btn")
-            .addEventListener("click", () => this._close());
+            .addEventListener("click", () =>
+              this.dispatchEvent(new DialogClosedEvent())
+            );
           this.shadowRoot
             .querySelector("#edit .restore-btn")
             .addEventListener("click", () => this._restoreSettings());
@@ -277,17 +279,8 @@
             });
         }
 
-        _close() {
-          this.dispatchEvent(
-            new CustomEvent("dialog-closed", {
-              bubbles: true,
-              composed: true,
-            })
-          );
-        }
-
         _displayErrorDialog(errorInfo) {
-          this._close();
+          this.dispatchEvent(new DialogClosedEvent());
           this.dispatchEvent(
             new CustomEvent("video-settings-failure", {
               detail: errorInfo,

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -171,12 +171,7 @@
           document.getElementsByClassName("close-overlay-with-primary-action")
         ).forEach((button) =>
           button.addEventListener("click", (evt) => {
-            evt.target.dispatchEvent(
-              new CustomEvent("dialog-closed", {
-                bubbles: true,
-                composed: true,
-              })
-            );
+            evt.target.dispatchEvent(new DialogClosedEvent());
           })
         );
       </script>
@@ -213,12 +208,7 @@
         document
           .getElementById("close-overlay-with-feature-btn")
           .addEventListener("click", (evt) => {
-            evt.target.dispatchEvent(
-              new CustomEvent("dialog-closed", {
-                bubbles: true,
-                composed: true,
-              })
-            );
+            evt.target.dispatchEvent(new DialogClosedEvent());
           });
       </script>
       <!-- Error overlay: -->


### PR DESCRIPTION
In order to avoid repetition in the dialogs we can (re-)use a centrally defined event class instead of implementing the same configuration in every dialog component.

I was considering to keep the internal `_close` methods, but ended up finding it more straightforward to dispatch the events right then and there. The class name of the event should be expressive enough and I find the control flow sufficiently easy to follow that way.

One note about `<debug-dialog>`: `_reset` is not needed on close, as the dialog is always initialised with `getLogs`, which will set the internal state to `logs-loading` as first thing, so the `null` state was never visible.

(Originated in https://github.com/mtlynch/tinypilot/pull/708.)