### PR TITLE
(Re-)Use centrally defined event for dialog failures

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -32,7 +32,7 @@ function isElementShown(id) {
 }
 
 /**
- * @see the `setup` method in error-dialog.html for the `errorInfo` param
+ * @see `DialogFailedEvent` for parameter `errorInfo`
  */
 function showError(errorInfo) {
   console.error(`${errorInfo.title}:\n${errorInfo.details}`);
@@ -337,7 +337,7 @@ document
     );
   });
 
-document.addEventListener("dialog-error", (evt) => {
+document.addEventListener("dialog-failed", (evt) => {
   showError(evt.detail);
 });
 

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -337,13 +337,13 @@ document
     );
   });
 
-const errorEvents = [
-  "update-failure",
-  "change-hostname-failure",
-  "shutdown-failure",
-  "video-settings-failure",
-  "debug-logs-failure",
-];
+document.addEventListener("dialog-error", (evt) => {
+  showError(evt.detail);
+});
+
+// TODO(jotaen) Keep this code to maintain compatibility with Pro; clean up
+//              eventually.
+const errorEvents = [];
 errorEvents.forEach((name) => {
   document.addEventListener(name, (evt) => {
     showError(evt.detail);

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -188,10 +188,12 @@
               this.state = "prompt";
             })
             .catch((error) => {
-              this._handleHostnameChangeFailure({
-                title: "Failed to Determine Hostname",
-                details: error,
-              });
+              this.dispatchEvent(
+                new DialogFailedEvent({
+                  title: "Failed to Determine Hostname",
+                  details: error,
+                })
+              );
             });
         }
 
@@ -234,10 +236,12 @@
                 this.state = "prompt";
                 return;
               }
-              this._handleHostnameChangeFailure({
-                title: "Failed to Change Hostname",
-                details: error,
-              });
+              this.dispatchEvent(
+                new DialogFailedEvent({
+                  title: "Failed to Change Hostname",
+                  details: error,
+                })
+              );
             });
         }
 
@@ -259,20 +263,17 @@
               window.location = futureLocation;
             })
             .catch((error) => {
-              this._handleHostnameChangeFailure({
-                title: "Failed to Redirect",
-                message:
-                  "Cannot reach TinyPilot under the new hostname. The device " +
-                  "may have failed to reboot, or your browser is failing to " +
-                  "resolve the new hostname.",
-                details: error,
-              });
+              this.dispatchEvent(
+                new DialogFailedEvent({
+                  title: "Failed to Redirect",
+                  message:
+                    "Cannot reach TinyPilot under the new hostname. The device " +
+                    "may have failed to reboot, or your browser is failing to " +
+                    "resolve the new hostname.",
+                  details: error,
+                })
+              );
             });
-        }
-
-        _handleHostnameChangeFailure(errorInfo) {
-          this.dispatchEvent(new DialogClosedEvent());
-          this.dispatchEvent(new DialogErrorEvent(errorInfo));
         }
       }
     );

--- a/app/templates/custom-elements/change-hostname-dialog.html
+++ b/app/templates/custom-elements/change-hostname-dialog.html
@@ -262,9 +262,9 @@
               this._handleHostnameChangeFailure({
                 title: "Failed to Redirect",
                 message:
-                  "Cannot reach TinyPilot under the new hostname. The device" +
+                  "Cannot reach TinyPilot under the new hostname. The device " +
                   "may have failed to reboot, or your browser is failing to " +
-                  " resolve the new hostname.",
+                  "resolve the new hostname.",
                 details: error,
               });
             });
@@ -272,13 +272,7 @@
 
         _handleHostnameChangeFailure(errorInfo) {
           this.dispatchEvent(new DialogClosedEvent());
-          this.dispatchEvent(
-            new CustomEvent("change-hostname-failure", {
-              detail: errorInfo,
-              bubbles: true,
-              composed: true,
-            })
-          );
+          this.dispatchEvent(new DialogErrorEvent(errorInfo));
         }
       }
     );

--- a/app/templates/custom-elements/debug-dialog.html
+++ b/app/templates/custom-elements/debug-dialog.html
@@ -154,10 +154,12 @@
               this.state = "logs-success";
             })
             .catch((error) => {
-              this._handleFailure({
-                title: "Error Retrieving Debug Logs",
-                details: error,
-              });
+              this.dispatchEvent(
+                new DialogFailedEvent({
+                  title: "Error Retrieving Debug Logs",
+                  details: error,
+                })
+              );
             });
         }
 
@@ -176,21 +178,18 @@
               this.state = "url-success";
             })
             .catch((error) => {
-              this._handleFailure({
-                title: "Error Retrieving Shareable URL",
-                details: error,
-              });
+              this.dispatchEvent(
+                new DialogFailedEvent({
+                  title: "Error Retrieving Shareable URL",
+                  details: error,
+                })
+              );
             });
         }
 
         onPushCopyButton(buttonElement, sourceElement) {
           copyElementTextToClipboard(sourceElement);
           buttonElement.innerText = "Copied!";
-        }
-
-        _handleFailure(errorInfo) {
-          this.dispatchEvent(new DialogClosedEvent());
-          this.dispatchEvent(new DialogErrorEvent(errorInfo));
         }
       }
     );

--- a/app/templates/custom-elements/debug-dialog.html
+++ b/app/templates/custom-elements/debug-dialog.html
@@ -190,13 +190,7 @@
 
         _handleFailure(errorInfo) {
           this.dispatchEvent(new DialogClosedEvent());
-          this.dispatchEvent(
-            new CustomEvent("debug-logs-failure", {
-              detail: errorInfo,
-              bubbles: true,
-              composed: true,
-            })
-          );
+          this.dispatchEvent(new DialogErrorEvent(errorInfo));
         }
       }
     );

--- a/app/templates/custom-elements/error-dialog.html
+++ b/app/templates/custom-elements/error-dialog.html
@@ -55,13 +55,7 @@
         }
 
         /**
-         * @param title   A concise summary of the error.
-         * @param message (string, optional) A user-friendly and helpful message
-         *                that ideally gives the user some guidance what to do
-         *                now. Defaults to a generic `DEFAULT_MESSAGE`.
-         * @param details (string|Error, optional) The technical error details,
-         *                e.g. the original error message from the API or
-         *                library call.
+         * @see `DialogErrorEvent` for description of parameters.
          */
         setup({ title, message = this.DEFAULT_MESSAGE, details = "" }) {
           this.shadowRoot.getElementById("title").innerText = title;

--- a/app/templates/custom-elements/error-dialog.html
+++ b/app/templates/custom-elements/error-dialog.html
@@ -55,7 +55,7 @@
         }
 
         /**
-         * @see `DialogErrorEvent` for description of parameters.
+         * @see `DialogFailedEvent` for description of parameters.
          */
         setup({ title, message = this.DEFAULT_MESSAGE, details = "" }) {
           this.shadowRoot.getElementById("title").innerText = title;

--- a/app/templates/custom-elements/overlay-panel.html
+++ b/app/templates/custom-elements/overlay-panel.html
@@ -58,9 +58,9 @@
     }
   }
 
-  class DialogErrorEvent extends CustomEvent {
+  class DialogFailedEvent extends CustomEvent {
     /**
-     * Event that causes the error dialog to be shown.
+     * Event that closes the dialog and displays the error dialog instead.
      * @param errorInfo object with the following properties:
      * - title (string) A concise summary of the error.
      * - message (string, optional) A user-friendly and helpful message that
@@ -70,7 +70,7 @@
      *   original error message from the API or library call.
      */
     constructor(errorInfo) {
-      super("dialog-error", {
+      super("dialog-failed", {
         detail: errorInfo,
         bubbles: true,
         composed: true,
@@ -91,6 +91,10 @@
           this.shadowRoot.appendChild(template.content.cloneNode(true));
           this.show = this.show.bind(this);
           this.shadowRoot.addEventListener("dialog-closed", () =>
+            this.show(false)
+          );
+          this.shadowRoot.addEventListener("dialog-failed", () =>
+            // This event is further handled in `app.js`.
             this.show(false)
           );
         }

--- a/app/templates/custom-elements/overlay-panel.html
+++ b/app/templates/custom-elements/overlay-panel.html
@@ -58,6 +58,26 @@
     }
   }
 
+  class DialogErrorEvent extends CustomEvent {
+    /**
+     * Event that causes the error dialog to be shown.
+     * @param errorInfo object with the following properties:
+     * - title (string) A concise summary of the error.
+     * - message (string, optional) A user-friendly and helpful message that
+     *   ideally gives the user some guidance what to do now. Defaults to a
+     *   generic message.
+     * - details (string|Error, optional) The technical error details, e.g. the
+     *   original error message from the API or library call.
+     */
+    constructor(errorInfo) {
+      super("dialog-error", {
+        detail: errorInfo,
+        bubbles: true,
+        composed: true,
+      });
+    }
+  }
+
   (function () {
     const doc = (document._currentScript || document.currentScript)
       .ownerDocument;

--- a/app/templates/custom-elements/shutdown-dialog.html
+++ b/app/templates/custom-elements/shutdown-dialog.html
@@ -119,15 +119,19 @@
             })
             .catch((error) => {
               if (restart) {
-                this._handleShutdownFailure({
-                  title: "Failed to Restart TinyPilot Device",
-                  details: error,
-                });
+                this.dispatchEvent(
+                  new DialogFailedEvent({
+                    title: "Failed to Restart TinyPilot Device",
+                    details: error,
+                  })
+                );
               } else {
-                this._handleShutdownFailure({
-                  title: "Failed to Shut Down TinyPilot Device",
-                  details: error,
-                });
+                this.dispatchEvent(
+                  new DialogFailedEvent({
+                    title: "Failed to Shut Down TinyPilot Device",
+                    details: error,
+                  })
+                );
               }
             });
         }
@@ -140,11 +144,6 @@
               composed: true,
             })
           );
-        }
-
-        _handleShutdownFailure(errorInfo) {
-          this.dispatchEvent(new DialogClosedEvent());
-          this.dispatchEvent(new DialogErrorEvent(errorInfo));
         }
       }
     );

--- a/app/templates/custom-elements/shutdown-dialog.html
+++ b/app/templates/custom-elements/shutdown-dialog.html
@@ -144,13 +144,7 @@
 
         _handleShutdownFailure(errorInfo) {
           this.dispatchEvent(new DialogClosedEvent());
-          this.dispatchEvent(
-            new CustomEvent("shutdown-failure", {
-              detail: errorInfo,
-              bubbles: true,
-              composed: true,
-            })
-          );
+          this.dispatchEvent(new DialogErrorEvent(errorInfo));
         }
       }
     );

--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -144,10 +144,12 @@
               }
             })
             .catch((error) => {
-              this._handleUpdateFailure({
-                title: "Failed to Retrieve Version Information",
-                details: error,
-              });
+              this.dispatchEvent(
+                new DialogFailedEvent({
+                  title: "Failed to Retrieve Version Information",
+                  details: error,
+                })
+              );
             });
         }
 
@@ -171,10 +173,12 @@
               this._state = "restarting";
             })
             .catch((error) => {
-              this._handleUpdateFailure({
-                title: "Failed to Restart TinyPilot Device",
-                details: error,
-              });
+              this.dispatchEvent(
+                new DialogFailedEvent({
+                  title: "Failed to Restart TinyPilot Device",
+                  details: error,
+                })
+              );
             });
         }
 
@@ -189,14 +193,16 @@
               this._state = "update-finished";
             })
             .catch((error) => {
-              this._handleUpdateFailure({
-                title: "Failed to Restart",
-                message:
-                  "Cannot reach TinyPilot after the update. The device " +
-                  "may have failed to reboot. Please manually reset your " +
-                  "device's power and try to connect again.",
-                details: error,
-              });
+              this.dispatchEvent(
+                new DialogFailedEvent({
+                  title: "Failed to Restart",
+                  message:
+                    "Cannot reach TinyPilot after the update. The device " +
+                    "may have failed to reboot. Please manually reset your " +
+                    "device's power and try to connect again.",
+                  details: error,
+                })
+              );
             });
         }
 
@@ -225,10 +231,12 @@
           try {
             await this._startUpdateWithRetries();
           } catch (error) {
-            this._handleUpdateFailure({
-              title: "Failed to Start Update",
-              details: error,
-            });
+            this.dispatchEvent(
+              new DialogFailedEvent({
+                title: "Failed to Start Update",
+                details: error,
+              })
+            );
             return;
           }
 
@@ -242,17 +250,14 @@
             await this._sleep(10 * 1000);
             await this._waitForReboot();
           } catch (error) {
-            this._handleUpdateFailure({
-              title: "Failed to Complete Update",
-              details: error,
-            });
+            this.dispatchEvent(
+              new DialogFailedEvent({
+                title: "Failed to Complete Update",
+                details: error,
+              })
+            );
             return;
           }
-        }
-
-        _handleUpdateFailure(errorInfo) {
-          this.dispatchEvent(new DialogClosedEvent());
-          this.dispatchEvent(new DialogErrorEvent(errorInfo));
         }
       }
     );

--- a/app/templates/custom-elements/update-dialog.html
+++ b/app/templates/custom-elements/update-dialog.html
@@ -252,13 +252,7 @@
 
         _handleUpdateFailure(errorInfo) {
           this.dispatchEvent(new DialogClosedEvent());
-          this.dispatchEvent(
-            new CustomEvent("update-failure", {
-              detail: errorInfo,
-              bubbles: true,
-              composed: true,
-            })
-          );
+          this.dispatchEvent(new DialogErrorEvent(errorInfo));
         }
       }
     );

--- a/app/templates/custom-elements/video-settings-dialog.html
+++ b/app/templates/custom-elements/video-settings-dialog.html
@@ -147,10 +147,12 @@
               this._setVideoFpsDisplay(videoFps);
             })
             .catch((error) => {
-              this._displayErrorDialog({
-                title: "Failed to Load Video FPS",
-                details: error,
-              });
+              this.dispatchEvent(
+                new DialogFailedEvent({
+                  title: "Failed to Load Video FPS",
+                  details: error,
+                })
+              );
               return Promise.reject(error);
             });
         }
@@ -165,10 +167,12 @@
               this._setVideoJpegQualityDisplay(videoJpegQuality);
             })
             .catch((error) => {
-              this._displayErrorDialog({
-                title: "Failed to Load Video JPEG Quality",
-                details: error,
-              });
+              this.dispatchEvent(
+                new DialogFailedEvent({
+                  title: "Failed to Load Video JPEG Quality",
+                  details: error,
+                })
+              );
               return Promise.reject(error);
             });
         }
@@ -195,10 +199,12 @@
               this._setVideoFpsDisplay(videoFps);
             })
             .catch((error) => {
-              this._displayErrorDialog({
-                title: "Failed to Restore Video FPS",
-                details: error,
-              });
+              this.dispatchEvent(
+                new DialogFailedEvent({
+                  title: "Failed to Restore Video FPS",
+                  details: error,
+                })
+              );
               return Promise.reject(error);
             });
         }
@@ -213,10 +219,12 @@
               this._setVideoJpegQualityDisplay(videoJpegQuality);
             })
             .catch((error) => {
-              this._displayErrorDialog({
-                title: "Failed to Restore Video JPEG Quality",
-                details: error,
-              });
+              this.dispatchEvent(
+                new DialogFailedEvent({
+                  title: "Failed to Restore Video JPEG Quality",
+                  details: error,
+                })
+              );
               return Promise.reject(error);
             });
         }
@@ -240,10 +248,12 @@
           let videoFps = this.shadowRoot.querySelector("#video-fps-slider")
             .value;
           return controllers.setVideoFps(videoFps).catch((error) => {
-            this._displayErrorDialog({
-              title: "Failed to Save Video FPS",
-              details: error,
-            });
+            this.dispatchEvent(
+              new DialogFailedEvent({
+                title: "Failed to Save Video FPS",
+                details: error,
+              })
+            );
             return Promise.reject(error);
           });
         }
@@ -255,10 +265,12 @@
           return controllers
             .setVideoJpegQuality(videoJpegQuality)
             .catch((error) => {
-              this._displayErrorDialog({
-                title: "Failed to Save Video JPEG Quality",
-                details: error,
-              });
+              this.dispatchEvent(
+                new DialogFailedEvent({
+                  title: "Failed to Save Video JPEG Quality",
+                  details: error,
+                })
+              );
               return Promise.reject(error);
             });
         }
@@ -277,11 +289,6 @@
               // Ignore errors here because they have already been handled by
               // their individual setting save function.
             });
-        }
-
-        _displayErrorDialog(errorInfo) {
-          this.dispatchEvent(new DialogClosedEvent());
-          this.dispatchEvent(new DialogErrorEvent(errorInfo));
         }
       }
     );

--- a/app/templates/custom-elements/video-settings-dialog.html
+++ b/app/templates/custom-elements/video-settings-dialog.html
@@ -281,13 +281,7 @@
 
         _displayErrorDialog(errorInfo) {
           this.dispatchEvent(new DialogClosedEvent());
-          this.dispatchEvent(
-            new CustomEvent("video-settings-failure", {
-              detail: errorInfo,
-              bubbles: true,
-              composed: true,
-            })
-          );
+          this.dispatchEvent(new DialogErrorEvent(errorInfo));
         }
       }
     );


### PR DESCRIPTION
Introduce a new central event class for dialog failure: `DialogFailedEvent`.

- A failure always terminates the dialog, so it’s redundant to trigger the closing explicitly. That is supposed to be reflected in the name “failed”.
- I think the event classes are the best place to describe the parameters, because this is what we regularly see and use when developing.
- As discussed, showing the error dialog is still happening in `app.js` as it is now. Not super nice, but works. I kept the old `errorEvents` array to not break Pro upon merging. (There might be a conflict due to prettier formatting, though.)
- Probably hard to spot in the diff: there was a whitespace/grammar issue in [the hostname dialog](https://github.com/mtlynch/tinypilot/compare/dialog-error-events?expand=1#diff-12f4fd7d48da269913c231ce1ea97a9700680ab75e655e60db6f62b7b8ac8286L265) due to string concatenating, which I also fixed. Other than that, I didn’t touch any of the copy.

(Originated in https://github.com/mtlynch/tinypilot/pull/708.)