### PR TITLE
Update URL for ansible-role-tinypilot

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -37,7 +37,7 @@ TinyPilot impersonates keyboard and mouse input using the Linux [USB Gadget API]
 
 To use the USB Gadget API, a device needs a USB port that operates in either device mode or supports USB OTG (which allows the port to switch between host mode and device mode). The Raspberry Pi 4B's USB-C port is the only port on the device capable of USB OTG, so this is the port that TinyPilot uses.
 
-TinyPilot [presents itself](https://github.com/mtlynch/ansible-role-tinypilot/blob/594be69c86fcdeaa9488690b2aef951acaf3bf64/files/init-usb-gadget) to the target computer as a USB Multifunction Composite Gadget (i.e., a USB hub) with a USB keyboard and mouse attached. This allows TinyPilot to send both keyboard and mouse input through a single USB connection.
+TinyPilot [presents itself](https://github.com/tiny-pilot/ansible-role-tinypilot/blob/594be69c86fcdeaa9488690b2aef951acaf3bf64/files/init-usb-gadget) to the target computer as a USB Multifunction Composite Gadget (i.e., a USB hub) with a USB keyboard and mouse attached. This allows TinyPilot to send both keyboard and mouse input through a single USB connection.
 
 ## nginx
 
@@ -64,6 +64,6 @@ As of Feb. 2021, uStreamer's maintainer is working on a H264 option, expected to
 
 ## Installation
 
-TinyPilot's installation process is somewhat unusual in that it depends on Ansible. The [`quick-install`](./quick-install) script bootstraps an Ansible environment on a Raspberry Pi and then uses [`ansible-role-tinypilot`](https://github.com/mtlynch/ansible-role-tinypilot) to install itself locally. `ansible-role-tinypilot` transitively includes other roles that TinyPilot depends on such as [`ansible-role-ustreamer`](https://github.com/mtlynch/ansible-role-ustreamer) and [`ansible-role-nginx`](https://github.com/geerlingguy/ansible-role-nginx).
+TinyPilot's installation process is somewhat unusual in that it depends on Ansible. The [`quick-install`](./quick-install) script bootstraps an Ansible environment on a Raspberry Pi and then uses [`ansible-role-tinypilot`](https://github.com/tiny-pilot/ansible-role-tinypilot) to install itself locally. `ansible-role-tinypilot` transitively includes other roles that TinyPilot depends on such as [`ansible-role-ustreamer`](https://github.com/mtlynch/ansible-role-ustreamer) and [`ansible-role-nginx`](https://github.com/geerlingguy/ansible-role-nginx).
 
 The `quick-install` script is also responsible for version-to-version updates and configuration changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ If you're planning to contribute code to TinyPilot, it's a good idea to enable t
 
 ### Enable mock scripts
 
-The TinyPilot server backend uses several privileged scripts (created in [ansible-role-tinypilot](https://github.com/mtlynch/ansible-role-tinypilot)). Those scripts exist on a provisioned TinyPilot device, but they don't exist on a dev machine.
+The TinyPilot server backend uses several privileged scripts (created in [ansible-role-tinypilot](https://github.com/tiny-pilot/ansible-role-tinypilot)). Those scripts exist on a provisioned TinyPilot device, but they don't exist on a dev machine.
 
 To set up symlinks that mock out those scripts and facilitate development, run the following command:
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ If you're interested in seeing what's happening with the project at a granular l
 ## See also
 
 * [TinyPilot Wiki](https://github.com/mtlynch/tinypilot/wiki): Guides for tasks related to TinyPilot.
-* [TinyPilot Ansible Role](https://github.com/mtlynch/ansible-role-tinypilot): Use [Ansible](https://docs.ansible.com/ansible/latest/index.html) to install TinyPilot and all dependencies as a systemd service.
+* [TinyPilot Ansible Role](https://github.com/tiny-pilot/ansible-role-tinypilot): Use [Ansible](https://docs.ansible.com/ansible/latest/index.html) to install TinyPilot and all dependencies as a systemd service.
 
 ## Acknowledgments
 

--- a/quick-install
+++ b/quick-install
@@ -154,13 +154,13 @@ roles_path = $PWD
 interpreter_python = /usr/bin/python3
 " > ansible.cfg
 
-TINYPILOT_ROLE_NAME="mtlynch.tinypilot"
+TINYPILOT_ROLE_NAME="ansible-role-tinypilot"
 if [ -d "$TINYPILOT_ROLE_NAME" ]; then
   pushd "$TINYPILOT_ROLE_NAME"
   git pull origin master
   popd
 else
-  TINYPILOT_ROLE_REPO="https://github.com/mtlynch/ansible-role-tinypilot.git"
+  TINYPILOT_ROLE_REPO="https://github.com/tiny-pilot/ansible-role-tinypilot.git"
   git clone "$TINYPILOT_ROLE_REPO" "$TINYPILOT_ROLE_NAME"
 fi
 


### PR DESCRIPTION
The role has moved from mtlynch/ansible-role-tinypilot to tiny-pilot/ansible-role-tinypilot, and we're no longer using Ansible Galaxy.

Related: https://github.com/mtlynch/ansible-role-tinypilot/pull/137