### PR TITLE
Add standalone / reusable dropdown button

### DIFF
--- a/app/static/css/icons.css
+++ b/app/static/css/icons.css
@@ -1,0 +1,20 @@
+.icon-arrow {
+  --width: 0.35rem;
+  --height: 0.55rem;
+  position: relative;
+  display: inline-block;
+  width: calc(var(--width) * 2);
+  height: 0;
+}
+
+.icon-arrow:after {
+  content: "";
+  position: absolute;
+  top: -0.55rem;
+  right: 0;
+  width: 0;
+  height: 0;
+  border-left: var(--width) solid transparent;
+  border-right: var(--width) solid transparent;
+  border-top: var(--height) solid var(--brand-creme-light);
+}

--- a/app/templates/custom-elements/button-dropdown.html
+++ b/app/templates/custom-elements/button-dropdown.html
@@ -99,8 +99,8 @@
         _handleCloseOnOutsideClick(evt) {
           const target = evt.composedPath()[0];
           // Skip if the user has clicked on the main button of this component.
-          // In this case the click event is already handled by the event
-          // handler of the button.
+          // In this case, the event handler of the button will already handle
+          // the click event.
           if (
             this.contains(target) &&
             (target.slot === "button" || target.parentElement.slot === "button")

--- a/app/templates/custom-elements/button-dropdown.html
+++ b/app/templates/custom-elements/button-dropdown.html
@@ -73,12 +73,15 @@
         }
 
         _toggleDropdown() {
-          const isShown = this.elements.dropdownItems.style.display === "block";
-          if (isShown) {
+          if (this._isDropdownShowing()) {
             this._closeDropdown();
           } else {
             this._showDropdown();
           }
+        }
+
+        _isDropdownShowing() {
+          return this.elements.dropdownItems.style.display === "block";
         }
 
         _showDropdown() {

--- a/app/templates/custom-elements/button-dropdown.html
+++ b/app/templates/custom-elements/button-dropdown.html
@@ -52,8 +52,9 @@
       "dropdown-button",
       class extends HTMLElement {
         connectedCallback() {
-          this.attachShadow({ mode: "open" });
-          this.shadowRoot.appendChild(template.content.cloneNode(true));
+          this.attachShadow({ mode: "open" }).appendChild(
+            template.content.cloneNode(true)
+          );
           this._handleCloseOnOutsideClick = this._handleCloseOnOutsideClick.bind(
             this
           );

--- a/app/templates/custom-elements/button-dropdown.html
+++ b/app/templates/custom-elements/button-dropdown.html
@@ -98,7 +98,9 @@
 
         _handleCloseOnOutsideClick(evt) {
           const target = evt.composedPath()[0];
-          // Skip if the event target is the button of this component instance:
+          // Skip if the user has clicked on the main button of this component.
+          // In this case the click event is already handled by the event
+          // handler of the button.
           if (
             this.contains(target) &&
             (target.slot === "button" || target.parentElement.slot === "button")

--- a/app/templates/custom-elements/button-dropdown.html
+++ b/app/templates/custom-elements/button-dropdown.html
@@ -1,0 +1,107 @@
+<template id="dropdown-button-template">
+  <style>
+    @import "css/style.css";
+
+    :host {
+      --offset-top: 1rem;
+      --offset-right: 1rem;
+      position: relative;
+      display: inline-block;
+    }
+
+    #dropdown-items {
+      display: none;
+      position: absolute;
+      min-width: 8em;
+      right: var(--offset-right);
+      padding: 0;
+      margin: calc(-1 * var(--offset-top)) 0 0 0;
+      z-index: var(--z-index-overlay);
+      background-color: var(--brand-metallic-light);
+      box-shadow: 0 0.2em 0.3rem rgba(0, 0, 0, 0.3);
+      text-align: right;
+    }
+
+    slot[name="item"]::slotted(li) {
+      display: block;
+      position: relative;
+      list-style: none;
+      padding: 0.3em 0.6em;
+      color: white;
+      cursor: pointer;
+    }
+
+    slot[name="item"]::slotted(li:hover) {
+      background-color: var(--brand-metallic-bright);
+    }
+  </style>
+
+  <slot name="button" id="dropdown-button"></slot>
+  <ul id="dropdown-items">
+    <slot name="item"></slot>
+  </ul>
+</template>
+
+<script>
+  (function () {
+    const doc = (document._currentScript || document.currentScript)
+      .ownerDocument;
+    const template = doc.querySelector("#dropdown-button-template");
+
+    customElements.define(
+      "dropdown-button",
+      class extends HTMLElement {
+        connectedCallback() {
+          this.attachShadow({ mode: "open" });
+          this.shadowRoot.appendChild(template.content.cloneNode(true));
+          this._handleCloseOnOutsideClick = this._handleCloseOnOutsideClick.bind(
+            this
+          );
+
+          this.elements = {
+            dropdownButton: this.shadowRoot.getElementById("dropdown-button"),
+            dropdownItems: this.shadowRoot.getElementById("dropdown-items"),
+          };
+          this.elements.dropdownButton.addEventListener("click", () =>
+            this._toggleDropdown()
+          );
+        }
+
+        disconnectedCallback() {
+          doc.removeEventListener("click", this._handleCloseOnOutsideClick);
+        }
+
+        _toggleDropdown() {
+          const isShown = this.elements.dropdownItems.style.display === "block";
+          if (isShown) {
+            this._closeDropdown();
+          } else {
+            this._showDropdown();
+          }
+        }
+
+        _showDropdown() {
+          this.elements.dropdownItems.style.display = "block";
+          doc.addEventListener("click", this._handleCloseOnOutsideClick);
+        }
+
+        _closeDropdown() {
+          this.elements.dropdownItems.style.display = "none";
+          doc.removeEventListener("click", this._handleCloseOnOutsideClick);
+        }
+
+        _handleCloseOnOutsideClick(evt) {
+          const target = evt.composedPath()[0];
+          // Skip if the event target is the button of this component instance:
+          if (
+            this.contains(target) &&
+            (target.slot === "button" || target.parentElement.slot === "button")
+          ) {
+            return;
+          }
+          this._closeDropdown();
+        }
+      }
+    );
+  })();
+</script>

--- a/app/templates/custom-elements/button-dropdown.html
+++ b/app/templates/custom-elements/button-dropdown.html
@@ -83,6 +83,8 @@
 
         _showDropdown() {
           this.elements.dropdownItems.style.display = "block";
+          // `addEventListener` will only register a function once, so it’s safe
+          // to call this method multiple times.
           doc.addEventListener("click", this._handleCloseOnOutsideClick);
         }
 

--- a/app/templates/styleguide.html
+++ b/app/templates/styleguide.html
@@ -8,6 +8,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
   </head>
   <style>
+    @import "css/icons.css";
+
     main {
       margin: 1rem auto;
       width: 40rem;
@@ -138,6 +140,27 @@
       <h3>Danger Button (Primary Action)</h3>
       <button class="btn-danger">Danger</button>
       <p>For destructive call-to-actions like “delete” or “shutdown”.</p>
+      <h3>Dropdown button</h3>
+      <p>
+        A button that groups multiple related actions.
+      </p>
+      <dropdown-button>
+        <button slot="button" class="btn-small btn-action">
+          Dropdown
+          <span class="icon-arrow"></span>
+        </button>
+        <li slot="item">Action 1</li>
+        <li slot="item">Action 2</li>
+        <li slot="item">Action 3</li>
+      </dropdown-button>
+      <dropdown-button>
+        <button slot="button" class="btn-small">
+          <span class="icon-arrow"></span>
+        </button>
+        <li slot="item">Action 1</li>
+        <li slot="item">Action 2</li>
+        <li slot="item">Action 3</li>
+      </dropdown-button>
 
       <h2 class="section">Overlay</h2>
       <p>


### PR DESCRIPTION
So far the dropdown button was custom in the virtual media overlay. In order to reuse it, this PR introduces it as standalone component.

- By using a slot, the component for opening/closing the dropdown can be completely customised. So it can be any button variant, but also other elements. The arrow icon is therefore separate, so that its exact styling/position can be controlled from the outside too.
- In contrast to before (in the virtual media dialog) the global event listeners are now only active when the dropdown is open. Before, they were registered all the time, which is unnecessary.

<img width="511" alt="Screenshot 2021-06-03 at 17 07 06" src="https://user-images.githubusercontent.com/3618384/120667827-26c86700-c48e-11eb-90d4-5fb6377d356b.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mtlynch/tinypilot/721)
<!-- Reviewable:end -->
